### PR TITLE
Add query helpers `MatchSingle` and `MatchAll` to nodeutil package

### DIFF
--- a/cache/loadingCache.go
+++ b/cache/loadingCache.go
@@ -57,3 +57,16 @@ func (c *LoadingCache) Get(key interface{}, load LoadFunc) (interface{}, error) 
 	c.cache.Add(key, v)
 	return v, nil
 }
+
+// DumpForTest returns all the entries in the cache. Not thread-safe and should
+// really only be used in tests as the function name suggests.
+func (c *LoadingCache) DumpForTest() map[interface{}]interface{} {
+	m := make(map[interface{}]interface{})
+	keys := c.cache.Keys()
+	for _, k := range keys {
+		if v, found := c.cache.Get(k); found {
+			m[k] = v
+		}
+	}
+	return m
+}

--- a/cache/loadingCache_test.go
+++ b/cache/loadingCache_test.go
@@ -66,7 +66,7 @@ func TestLoadingCache_Get(t *testing.T) {
 		load          LoadFunc
 		expectedError error
 		expectedVal   string
-		expectedKVs   map[string]string
+		expectedCache map[interface{}]interface{}
 	}{
 		{
 			name:          "cache hit",
@@ -75,7 +75,7 @@ func TestLoadingCache_Get(t *testing.T) {
 			load:          nil,
 			expectedError: nil,
 			expectedVal:   "two",
-			expectedKVs:   map[string]string{"1": "one", "2": "two"},
+			expectedCache: map[interface{}]interface{}{"1": "one", "2": "two"},
 		},
 		{
 			name:  "cache miss, loading error",
@@ -86,7 +86,7 @@ func TestLoadingCache_Get(t *testing.T) {
 			},
 			expectedError: errors.New("test error"),
 			expectedVal:   "",
-			expectedKVs:   map[string]string{"1": "one", "2": "two"},
+			expectedCache: map[interface{}]interface{}{"1": "one", "2": "two"},
 		},
 		{
 			name:  "cache miss, loading okay, no eviction",
@@ -97,7 +97,7 @@ func TestLoadingCache_Get(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedVal:   "three",
-			expectedKVs:   map[string]string{"1": "one", "2": "two", "3": "three"},
+			expectedCache: map[interface{}]interface{}{"1": "one", "2": "two", "3": "three"},
 		},
 		{
 			name:  "cache miss, loading okay, eviction",
@@ -108,7 +108,7 @@ func TestLoadingCache_Get(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedVal:   "three",
-			expectedKVs:   map[string]string{"2": "two", "3": "three"},
+			expectedCache: map[interface{}]interface{}{"2": "two", "3": "three"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -125,14 +125,7 @@ func TestLoadingCache_Get(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, test.expectedVal, val.(string))
 			}
-			// Do post Get() call cache check.
-			kvs := make(map[string]string)
-			for _, k := range test.cache.cache.Keys() {
-				v, found := test.cache.cache.Get(k)
-				assert.True(t, found)
-				kvs[k.(string)] = v.(string)
-			}
-			assert.Equal(t, test.expectedKVs, kvs)
+			assert.Equal(t, test.expectedCache, test.cache.DumpForTest())
 		})
 	}
 }

--- a/nodeutil/query.go
+++ b/nodeutil/query.go
@@ -1,0 +1,91 @@
+package nodeutil
+
+import (
+	"errors"
+	"fmt"
+
+	node "github.com/antchfx/xmlquery"
+	"github.com/antchfx/xpath"
+
+	"github.com/jf-tech/omniparser/cache"
+)
+
+var (
+	// ErrNoMatch is returned when not a single matched node can be found.
+	ErrNoMatch = errors.New("no match")
+	// ErrMoreThanExpected is returned when more than expected matched nodes are found.
+	ErrMoreThanExpected = errors.New("more than expected matched")
+)
+
+const (
+	// DisableXPathCache disables caching xpath compilation when MatchAll/MatchSingle
+	// are called. Useful when caller knows the xpath string isn't cache-able (such as
+	// containing unique IDs, timestamps, etc) which would otherwise cause the xpath
+	// compilation cache grow unbounded.
+	DisableXPathCache = uint(1) << iota
+)
+
+// XPathExprCache is the default loading cache used for caching the compiled
+// xpath expression. If the default size is too big/small and/or a cache limit isn't
+// desired at all, caller can simply replace the cache during global initialization.
+// But be aware it's global so any packages uses this package inside your process will
+// be affected.
+var XPathExprCache = cache.NewLoadingCache()
+
+func loadXPathExpr(expr string, flags []uint) (*xpath.Expr, error) {
+	var flagsActual uint
+	switch len(flags) {
+	case 0:
+		flagsActual = 0
+	case 1:
+		flagsActual = flags[0]
+	default:
+		return nil, fmt.Errorf("only one flag is allowed, instead got: %v", flags)
+	}
+	var exp interface{}
+	var err error
+	if flagsActual&DisableXPathCache != 0 {
+		exp, err = xpath.Compile(expr)
+	} else {
+		exp, err = XPathExprCache.Get(expr, func(key interface{}) (interface{}, error) {
+			return xpath.Compile(key.(string))
+		})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("xpath '%s' compilation failed: %s", expr, err.Error())
+	}
+	return exp.(*xpath.Expr), nil
+}
+
+// MatchAll uses the given xpath expression 'expr' to find all the matching nodes
+// contained in the tree rooted at 'top'.
+func MatchAll(top *node.Node, expr string, flags ...uint) ([]*node.Node, error) {
+	// We have quite a few places a simple "." xpath query can be issued, a simple
+	// optimization to reduce workload in that situation.
+	if expr == "." {
+		return []*node.Node{top}, nil
+	}
+	exp, err := loadXPathExpr(expr, flags)
+	if err != nil {
+		return nil, err
+	}
+	return node.QuerySelectorAll(top, exp), nil
+}
+
+// MatchSingle uses the given xpath expression 'expr' to find one and exactly one matching node
+// contained in the tree rooted at 'top'. If no matching node is found, ErrNoMatch is returned;
+// if more than one matching nodes are found, ErrMoreThanExpected is returned.
+func MatchSingle(top *node.Node, expr string, flags ...uint) (*node.Node, error) {
+	nodes, err := MatchAll(top, expr, flags...)
+	if err != nil {
+		return nil, err
+	}
+	switch len(nodes) {
+	case 0:
+		return nil, ErrNoMatch
+	case 1:
+		return nodes[0], nil
+	default:
+		return nil, ErrMoreThanExpected
+	}
+}

--- a/nodeutil/query_test.go
+++ b/nodeutil/query_test.go
@@ -1,0 +1,102 @@
+package nodeutil
+
+import (
+	"strings"
+	"testing"
+
+	node "github.com/antchfx/xmlquery"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/cache"
+)
+
+func TestMatchAll(t *testing.T) {
+	s := `
+	<AAA>
+		<BBB id="1"/>
+		<CCC id="2">
+			<DDD/>
+		</CCC>
+		<CCC id="3">
+			<DDD/>
+		</CCC>
+	</AAA>`
+	top, err := node.Parse(strings.NewReader(s))
+	assert.NoError(t, err)
+	assert.NotNil(t, top)
+
+	XPathExprCache = cache.NewLoadingCache() // TODO: make parallel unit test happy.
+	assert.Equal(t, 0, len(XPathExprCache.DumpForTest()))
+
+	top, err = MatchSingle(top, "/AAA")
+	assert.NoError(t, err)
+	assert.NotNil(t, top)
+	assert.Equal(t, 1, len(XPathExprCache.DumpForTest())) // "/AAA" added to xpath expr cache.
+
+	n, err := MatchAll(top, "BBB")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(n))
+	assert.Equal(t, `<BBB id="1"></BBB>`, n[0].OutputXML(true))
+	assert.Equal(t, 2, len(XPathExprCache.DumpForTest())) // "BBB" added to xpath expr cache.
+
+	n, err = MatchAll(top, "CCC", DisableXPathCache)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(n))
+	assert.Equal(t, `<CCC id="2"><DDD></DDD></CCC>`, n[0].OutputXML(true))
+	assert.Equal(t, `<CCC id="3"><DDD></DDD></CCC>`, n[1].OutputXML(true))
+	assert.Equal(t, 2, len(XPathExprCache.DumpForTest())) // "CCC" shouldn't be added to cache.
+
+	n, err = MatchAll(top, "CCC[@id='2']")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(n))
+	assert.Equal(t, `<CCC id="2"><DDD></DDD></CCC>`, n[0].OutputXML(true))
+	n2, err := MatchAll(n[0], ".")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(n2))
+	assert.Equal(t, n[0], n2[0])
+
+	// only one flag can be passed.
+	n, err = MatchAll(top, "CCC[@id='2']", 0, 1)
+	assert.Error(t, err)
+	assert.Equal(t, "only one flag is allowed, instead got: [0 1]", err.Error())
+	assert.Nil(t, n)
+
+	// invalid xpath
+	n, err = MatchAll(top, "[invalid")
+	assert.Error(t, err)
+	assert.Equal(t, "xpath '[invalid' compilation failed: expression must evaluate to a node-set", err.Error())
+	assert.Nil(t, n)
+}
+
+func TestMatchSingle(t *testing.T) {
+	s := `
+	<AAA>
+		<BBB id="1"/>
+		<CCC id="2">
+			<DDD/>
+		</CCC>
+		<CCC id="3">
+			<DDD/>
+		</CCC>
+	</AAA>`
+	top, err := node.Parse(strings.NewReader(s))
+	assert.NoError(t, err)
+	assert.NotNil(t, top)
+
+	n, err := MatchSingle(top, "[invalid")
+	assert.Error(t, err)
+	assert.Equal(t, "xpath '[invalid' compilation failed: expression must evaluate to a node-set", err.Error())
+	assert.Nil(t, n)
+
+	n, err = MatchSingle(top, "/NON_EXISTING")
+	assert.Equal(t, ErrNoMatch, err)
+	assert.Nil(t, n)
+
+	n, err = MatchSingle(top, "/AAA/CCC")
+	assert.Equal(t, ErrMoreThanExpected, err)
+	assert.Nil(t, n)
+
+	n, err = MatchSingle(top, "/AAA/CCC[@id=2]")
+	assert.NoError(t, err)
+	assert.Equal(t, `<CCC id="2"><DDD></DDD></CCC>`, n.OutputXML(true))
+}


### PR DESCRIPTION
In omniparser, we need a lot xpath querying, some prefers caching on some requires caching off. Add two helpers `MatchSingle` and `MatchAll` to the `nodeutil` package to make life easier.