### PR TITLE
Intro Parser interface, SchemaPlugin interface and NewParser func

### DIFF
--- a/omniparser/errs/ctxAwareErr.go
+++ b/omniparser/errs/ctxAwareErr.go
@@ -1,0 +1,9 @@
+package errs
+
+// CtxAwareErr formats and creates an error is context aware: e.g. during schema parsing and
+// validation, implementation of this interface can give us errors prefixed with schema name
+// and line number. In input parsing and processing, it can give us errors prefixed with input
+// stream (file) name and line number, etc.
+type CtxAwareErr interface {
+	FmtErr(format string, args ...interface{}) error
+}

--- a/omniparser/parser.go
+++ b/omniparser/parser.go
@@ -1,8 +1,13 @@
 package omniparser
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
+	"io/ioutil"
 
+	"github.com/jf-tech/omniparser/jsons"
+	"github.com/jf-tech/omniparser/omniparser/customfuncs"
 	"github.com/jf-tech/omniparser/omniparser/schemaplugin"
 	"github.com/jf-tech/omniparser/omniparser/transformctx"
 )
@@ -21,5 +26,80 @@ import (
 type Parser interface {
 	GetTransformOp(name string, input io.Reader, ctx *transformctx.Ctx) (TransformOp, error)
 	SchemaHeader() schemaplugin.Header
-	SchemaRawContent() string
+	SchemaContent() []byte
+}
+
+// Extension allows client of omniparser to supply its own custom funcs and/or schema plugin.
+type Extension struct {
+	CustomFuncs customfuncs.CustomFuncs
+	ParseSchema schemaplugin.SchemaParserFunc
+}
+
+var BuiltinExtensions = []Extension{
+	{
+		CustomFuncs: customfuncs.BuiltinCustomFuncs,
+	},
+}
+
+type parser struct {
+	schemaName    string
+	schemaHeader  schemaplugin.Header
+	schemaContent []byte
+	exts          []Extension
+	schemaPlugin  schemaplugin.Plugin
+}
+
+// NewParser creates a new instance of omniparser for a given schema. Caller can also supply
+// additional extensions (on top of builtin extensions) so caller can adds new custom funcs and/or
+// new schema plugins.
+func NewParser(schemaName string, schemaReader io.Reader, exts ...Extension) (Parser, error) {
+	schemaContent, err := ioutil.ReadAll(schemaReader)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read schema '%s': %s", schemaName, err.Error())
+	}
+	var schemaHeader schemaplugin.Header
+	err = json.Unmarshal(schemaContent, &schemaHeader)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unable to read schema '%s': corrupted header `parser_settings`: %s", schemaName, err)
+	}
+	var allExts []Extension
+	allExts = append(allExts, exts...)
+	allExts = append(allExts, BuiltinExtensions...)
+	for _, ext := range allExts {
+		if ext.ParseSchema == nil {
+			continue
+		}
+		plugin, err := ext.ParseSchema(schemaName, schemaHeader, schemaContent)
+		if err == schemaplugin.ErrSchemaNotSupported {
+			continue
+		}
+		if err != nil {
+			// The err from plugin's ParseSchema is already ctxAwareErr formatted, so directly return.
+			return nil, err
+		}
+		return &parser{
+			schemaName:    schemaName,
+			schemaHeader:  schemaHeader,
+			schemaContent: schemaContent,
+			exts:          allExts,
+			schemaPlugin:  plugin,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported schema '%s':\n%s", schemaName, jsons.BPM(schemaHeader))
+}
+
+// GetTransformOp creates and returns an instance of TransformOp for a given input.
+func (p *parser) GetTransformOp(name string, input io.Reader, ctx *transformctx.Ctx) (TransformOp, error) {
+	panic("TBD")
+}
+
+// SchemaHeader returns the associated schema plugin's schema header.
+func (p *parser) SchemaHeader() schemaplugin.Header {
+	return p.schemaHeader
+}
+
+// SchemaContent returns the associated schema plugin's schema content.
+func (p *parser) SchemaContent() []byte {
+	return p.schemaContent
 }

--- a/omniparser/parser_test.go
+++ b/omniparser/parser_test.go
@@ -1,0 +1,106 @@
+package omniparser
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/omniparser/schemaplugin"
+	"github.com/jf-tech/omniparser/testlib"
+)
+
+func TestNewParser(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		schema      string
+		exts        []Extension
+		expectedErr string
+	}{
+		{
+			name:        "fail to read out schema content",
+			schema:      "",
+			exts:        nil,
+			expectedErr: "unable to read schema 'test-schema': mock reading failure",
+		},
+		{
+			name:        "fail to unmarshal schema header",
+			schema:      "[invalid",
+			exts:        nil,
+			expectedErr: "unable to read schema 'test-schema': corrupted header `parser_settings`:.*",
+		},
+		{
+			name:   "no supported schema plugin",
+			schema: `{"parser_settings": {"version": "9999", "file_format_type": "exe" }}`,
+			exts: []Extension{
+				{}, // Empty extension to test if we skip empty extension properly or not.
+				{
+					ParseSchema: func(string, schemaplugin.Header, []byte) (schemaplugin.Plugin, error) {
+						return nil, schemaplugin.ErrSchemaNotSupported
+					},
+				},
+			},
+			expectedErr: "unsupported schema 'test-schema':.*",
+		},
+		{
+			name:   "supported schema plugin found, but schema validation fails",
+			schema: `{"parser_settings": {"version": "9999", "file_format_type": "exe" }}`,
+			exts: []Extension{
+				{
+					ParseSchema: func(string, schemaplugin.Header, []byte) (schemaplugin.Plugin, error) {
+						return nil, errors.New("invalid schema")
+					},
+				},
+			},
+			expectedErr: "invalid schema",
+		},
+		{
+			name:   "supported schema plugin found, schema parsing successful",
+			schema: `{"parser_settings": {"version": "9999", "file_format_type": "exe" }}`,
+			exts: []Extension{
+				{
+					ParseSchema: func(string, schemaplugin.Header, []byte) (schemaplugin.Plugin, error) {
+						return nil, nil
+					},
+				},
+			},
+			expectedErr: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var schemaReader io.Reader
+			if test.schema == "" {
+				schemaReader = testlib.NewMockReadCloser("mock reading failure", nil)
+			} else {
+				schemaReader = strings.NewReader(test.schema)
+			}
+			plugin, err := NewParser("test-schema", schemaReader, test.exts...)
+			if test.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Regexp(t, test.expectedErr, err.Error())
+				assert.Nil(t, plugin)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, plugin)
+				assert.Equal(t, test.schema, string(plugin.SchemaContent()))
+			}
+		})
+	}
+}
+
+func TestParser(t *testing.T) {
+	header := schemaplugin.Header{
+		ParserSettings: schemaplugin.ParserSettings{Version: "999", FileFormatType: "exe"},
+	}
+	p := &parser{
+		schemaHeader:  header,
+		schemaContent: []byte("test schema content"),
+	}
+	assert.Panics(t, func() {
+		_, _ = p.GetTransformOp("name", nil, nil)
+	})
+	assert.Equal(t, header, p.SchemaHeader())
+	assert.Equal(t, []byte("test schema content"), p.SchemaContent())
+}

--- a/omniparser/schemaplugin/plugin.go
+++ b/omniparser/schemaplugin/plugin.go
@@ -1,0 +1,35 @@
+package schemaplugin
+
+import (
+	"errors"
+	"io"
+
+	"github.com/jf-tech/omniparser/omniparser/transformctx"
+)
+
+// ErrSchemaNotSupported indicates a schema is not supported by a plugin.
+var ErrSchemaNotSupported = errors.New("schema not supported")
+
+// SchemaParserFunc is a type of a func that checks if a given schema is supported by
+// its associated plugin, and, if yes, parses the schema content, creates and initializes
+// a new instance of its associated plugin.
+// If the given schema is not supported, ErrSchemaNotSupported should be returned.
+// Any other error returned will cause omniparser to fail entirely.
+// Note, any non ErrSchemaNotSupported error returned here should be errs.CtxAwareErr
+// formatted (i.e. error should contain schema name and if possible error line number).
+type SchemaParserFunc func(name string, header Header, content []byte) (Plugin, error)
+
+// Plugin is an interface representing a schema plugin responsible for processing input
+// stream based on its given schema.
+type Plugin interface {
+	// GetInputProcessor returns an InputProcessor for an input stream.
+	// Omniparser will not call GetInputProcessor unless ParseSchema has returned supported.
+	// Omniparser calls GetInputProcessor when client supplies an input stream and is ready
+	// for the parser to process/transform the input.
+	GetInputProcessor(ctx *transformctx.Ctx, input io.Reader) (InputProcessor, error)
+}
+
+// InputProcessor is an interface responsible for a given input stream
+// parsing and processing.
+type InputProcessor interface {
+}

--- a/testlib/mockReaderCloser.go
+++ b/testlib/mockReaderCloser.go
@@ -1,0 +1,27 @@
+package testlib
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+type alwaysFailReadCloser struct{ err error }
+
+// Read always returns the designated error.
+func (a alwaysFailReadCloser) Read([]byte) (int, error) { return 0, a.err }
+
+// Close always returns the designated error.
+func (a alwaysFailReadCloser) Close() error { return a.err }
+
+type bytesReadCloser struct{ underlying io.Reader }
+
+func (b bytesReadCloser) Read(p []byte) (n int, err error) { return b.underlying.Read(p) }
+func (bytesReadCloser) Close() error                       { return nil }
+
+func NewMockReadCloser(failureMsg string, content []byte) io.ReadCloser {
+	if failureMsg != "" {
+		return alwaysFailReadCloser{errors.New(failureMsg)}
+	}
+	return bytesReadCloser{bytes.NewReader(content)}
+}

--- a/testlib/mockReaderCloser_test.go
+++ b/testlib/mockReaderCloser_test.go
@@ -1,0 +1,26 @@
+package testlib
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMockReadCloser(t *testing.T) {
+	reader := NewMockReadCloser("test failure", nil)
+	_, err := ioutil.ReadAll(reader)
+	assert.Error(t, err)
+	assert.Equal(t, "test failure", err.Error())
+	err = reader.Close()
+	assert.Error(t, err)
+	assert.Equal(t, "test failure", err.Error())
+
+	content := "this is a test"
+	reader = NewMockReadCloser("", []byte(content))
+	actualContent, err := ioutil.ReadAll(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, content, string(actualContent))
+	err = reader.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
`Parser` is the main interface for omniparser (along with `NewParser` is func to create a Parser)

Each schema corresponds to a `SchemaPlugin`.

Add these two main interfaces and associated type definitions to define the skeleton of omniparser.