### PR TITLE
Introduce the last (at least for now) mode of extensibility: `custom_parse`

### DIFF
--- a/omniparser/schemaplugin/omni/v2/inputprocessor.go
+++ b/omniparser/schemaplugin/omni/v2/inputprocessor.go
@@ -12,10 +12,11 @@ import (
 )
 
 type inputProcessor struct {
-	finalOutputDecl *transform.Decl
-	customFuncs     customfuncs.CustomFuncs
-	ctx             *transformctx.Ctx
-	reader          omniv2fileformat.FormatReader
+	finalOutputDecl  *transform.Decl
+	customFuncs      customfuncs.CustomFuncs
+	customParseFuncs transform.CustomParseFuncs
+	ctx              *transformctx.Ctx
+	reader           omniv2fileformat.FormatReader
 }
 
 func (p *inputProcessor) Read() ([]byte, error) {
@@ -24,7 +25,8 @@ func (p *inputProcessor) Read() ([]byte, error) {
 		// Read() supposed to have already done CtxAwareErr error wrapping. So directly return.
 		return nil, err
 	}
-	result, err := transform.NewParseCtx(p.ctx, p.customFuncs).ParseNode(node, p.finalOutputDecl)
+	result, err := transform.NewParseCtx(p.ctx, p.customFuncs, p.customParseFuncs).
+		ParseNode(node, p.finalOutputDecl)
 	if err != nil {
 		// ParseNode() error not CtxAwareErr wrapped, so wrap it.
 		// Note errs.ErrorTransformFailed is a continuable error.

--- a/omniparser/schemaplugin/omni/v2/inputprocessor_test.go
+++ b/omniparser/schemaplugin/omni/v2/inputprocessor_test.go
@@ -52,7 +52,7 @@ func TestInputProcessor_Read_ParseNodeFailure(t *testing.T) {
 			"transform_declarations": {
 				"FINAL_OUTPUT": { "const": "abc", "result_type": "int" }
 			}
-		}`), nil)
+		}`), nil, nil)
 	assert.NoError(t, err)
 	p := &inputProcessor{
 		finalOutputDecl: finalOutputDecl,
@@ -74,7 +74,7 @@ func TestInputProcessor_Read_Success(t *testing.T) {
 			"transform_declarations": {
 				"FINAL_OUTPUT": { "const": "123", "result_type": "int" }
 			}
-		}`), nil)
+		}`), nil, nil)
 	assert.NoError(t, err)
 	p := &inputProcessor{
 		finalOutputDecl: finalOutputDecl,

--- a/omniparser/schemaplugin/omni/v2/transform/.snapshots/TestValidateTransformDeclarations-success
+++ b/omniparser/schemaplugin/omni/v2/transform/.snapshots/TestValidateTransformDeclarations-success
@@ -200,6 +200,12 @@
 			],
 			"parent": "FINAL_OUTPUT"
 		},
+		"field_13": {
+			"custom_parse": "test_custom_parse",
+			"fqdn": "FINAL_OUTPUT.field_13",
+			"kind": "custom_parse",
+			"parent": "FINAL_OUTPUT"
+		},
 		"field_9": {
 			"xpath": "1/2/3",
 			"object": {
@@ -228,6 +234,7 @@
 		"FINAL_OUTPUT.field_10",
 		"FINAL_OUTPUT.field_11",
 		"FINAL_OUTPUT.field_12",
+		"FINAL_OUTPUT.field_13",
 		"FINAL_OUTPUT.field_9"
 	],
 	"parent": "(nil)"

--- a/omniparser/schemaplugin/omni/v2/transform/decl.go
+++ b/omniparser/schemaplugin/omni/v2/transform/decl.go
@@ -10,14 +10,15 @@ import (
 type Kind string
 
 const (
-	KindUnknown    Kind = "unknown"
-	KindConst      Kind = "const"
-	KindExternal   Kind = "external"
-	KindField      Kind = "field"
-	KindObject     Kind = "object"
-	KindArray      Kind = "array"
-	KindCustomFunc Kind = "custom_func"
-	KindTemplate   Kind = "template"
+	KindUnknown     Kind = "unknown"
+	KindConst       Kind = "const"
+	KindExternal    Kind = "external"
+	KindField       Kind = "field"
+	KindObject      Kind = "object"
+	KindArray       Kind = "array"
+	KindCustomFunc  Kind = "custom_func"
+	KindCustomParse Kind = "custom_parse"
+	KindTemplate    Kind = "template"
 )
 
 // ResultType specifies the types of omni schema's output elements.
@@ -83,6 +84,8 @@ type Decl struct {
 	XPathDynamic *Decl `json:"xpath_dynamic,omitempty"`
 	// CustomFunc specifies the input element is a custom function.
 	CustomFunc *CustomFuncDecl `json:"custom_func,omitempty"`
+	// CustomParse specifies the input element is to be custom parsed.
+	CustomParse *string `json:"custom_parse,omitempty"`
 	// Template specifies the input element is a template.
 	Template *string `json:"template,omitempty"`
 	// Object specifies the input element is an object.
@@ -143,7 +146,11 @@ func (d *Decl) resultType() ResultType {
 		switch d.kind {
 		case KindConst, KindExternal, KindField, KindCustomFunc:
 			return ResultTypeString
-		case KindObject:
+		case KindObject, KindCustomParse:
+			// By default KindCustomParse is considered to be returning
+			// object (If schema writer wants wants it to return string
+			// or any other type, that's fine, as long as that specific
+			// result_type is explicitly stated in the schema.
 			return ResultTypeObject
 		case KindArray:
 			return ResultTypeArray
@@ -184,6 +191,7 @@ func (d *Decl) deepCopy() *Decl {
 	if d.CustomFunc != nil {
 		dest.CustomFunc = d.CustomFunc.deepCopy()
 	}
+	dest.CustomParse = strs.CopyStrPtr(d.CustomParse)
 	dest.Template = strs.CopyStrPtr(d.Template)
 	if len(d.Object) > 0 {
 		dest.Object = map[string]*Decl{}

--- a/omniparser/schemaplugin/omni/v2/transform/decl_test.go
+++ b/omniparser/schemaplugin/omni/v2/transform/decl_test.go
@@ -154,6 +154,7 @@ func verifyDeclDeepCopy(t *testing.T, d1, d2 *Decl) {
 			verifyDeclDeepCopy(t, d1.CustomFunc.Args[i], d2.CustomFunc.Args[i])
 		}
 	}
+	verifyPtrsInDeepCopy(d1.CustomParse, d2.CustomParse)
 
 	verifyPtrsInDeepCopy(d1.Template, d2.Template)
 
@@ -200,7 +201,8 @@ func TestDeclDeepCopy(t *testing.T) {
             { "object": {
                 "field831": { "const": "value831" }
             }}
-        ]}
+        ]},
+		"field9": { "xpath": "value9", "custom_parse": "cp9" }
     }}`
 	var src Decl
 	assert.NoError(t, json.Unmarshal([]byte(declJson), &src))

--- a/omniparser/schemaplugin/omni/v2/transform/invokeCustomParse.go
+++ b/omniparser/schemaplugin/omni/v2/transform/invokeCustomParse.go
@@ -1,0 +1,29 @@
+package transform
+
+import (
+	"reflect"
+
+	node "github.com/antchfx/xmlquery"
+
+	"github.com/jf-tech/omniparser/omniparser/transformctx"
+)
+
+// CustomParseFuncType represents a custom_parse function type.
+type CustomParseFuncType func(*transformctx.Ctx, *node.Node) (interface{}, error)
+
+// CustomParseFuncs is a map from custom_parse names to an actual custom parse functions.
+type CustomParseFuncs = map[string]CustomParseFuncType
+
+func (p *parseCtx) invokeCustomParse(customParseFn CustomParseFuncType, n *node.Node) (interface{}, error) {
+	result := reflect.ValueOf(customParseFn).Call(
+		[]reflect.Value{
+			reflect.ValueOf(p.opCtx),
+			reflect.ValueOf(n),
+		})
+	// result[0] - result
+	// result[1] - error
+	if result[1].Interface() == nil {
+		return result[0].Interface(), nil
+	}
+	return nil, result[1].Interface().(error)
+}

--- a/omniparser/schemaplugin/omni/v2/transform/invokeCustomParse_test.go
+++ b/omniparser/schemaplugin/omni/v2/transform/invokeCustomParse_test.go
@@ -1,0 +1,56 @@
+package transform
+
+import (
+	"errors"
+	"testing"
+
+	node "github.com/antchfx/xmlquery"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/omniparser/transformctx"
+)
+
+func TestInvokeCustomParse(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		customParse CustomParseFuncType
+		n           *node.Node
+		expected    interface{}
+		expectedErr string
+	}{
+		{
+			name: "success",
+			customParse: func(ctx *transformctx.Ctx, n *node.Node) (interface{}, error) {
+				assert.Equal(t, "test-input", ctx.InputName)
+				assert.Equal(t, "123", n.InnerText())
+				return "321", nil
+			},
+			n:           &node.Node{Type: node.TextNode, Data: "123"},
+			expected:    "321",
+			expectedErr: "",
+		},
+		{
+			name: "failure",
+			customParse: func(ctx *transformctx.Ctx, n *node.Node) (interface{}, error) {
+				assert.Equal(t, "test-input", ctx.InputName)
+				assert.Equal(t, "123", n.InnerText())
+				return nil, errors.New("test failure")
+			},
+			n:           &node.Node{Type: node.TextNode, Data: "123"},
+			expected:    nil,
+			expectedErr: "test failure",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := testParseCtx().invokeCustomParse(test.customParse, test.n)
+			if test.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.expectedErr, err.Error())
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, result)
+			}
+		})
+	}
+}

--- a/omniparser/schemavalidate/jsonschemas/transform_declarations.json
+++ b/omniparser/schemavalidate/jsonschemas/transform_declarations.json
@@ -14,6 +14,7 @@
                         { "$ref": "#/definitions/field" },
                         { "$ref": "#/definitions/object" },
                         { "$ref": "#/definitions/custom_func" },
+                        { "$ref": "#/definitions/custom_parse" },
                         { "$ref": "#/definitions/array" },
                         { "$ref": "#/definitions/template" }
                     ]
@@ -27,6 +28,7 @@
                         { "$ref": "#/definitions/field" },
                         { "$ref": "#/definitions/object" },
                         { "$ref": "#/definitions/custom_func" },
+                        { "$ref": "#/definitions/custom_parse" },
                         { "$ref": "#/definitions/array" },
                         { "$ref": "#/definitions/template" }
                     ]
@@ -69,6 +71,7 @@
                     { "$ref": "#/definitions/external" },
                     { "$ref": "#/definitions/field" },
                     { "$ref": "#/definitions/custom_func" },
+                    { "$ref": "#/definitions/custom_parse" },
                     { "$ref": "#/definitions/template" }
                 ]
             }
@@ -88,6 +91,7 @@
                         { "$ref": "#/definitions/field" },
                         { "$ref": "#/definitions/object" },
                         { "$ref": "#/definitions/custom_func" },
+                        { "$ref": "#/definitions/custom_parse" },
                         { "$ref": "#/definitions/array" },
                         { "$ref": "#/definitions/template" }
                     ],
@@ -108,6 +112,7 @@
                             { "$ref": "#/definitions/external" },
                             { "$ref": "#/definitions/field" },
                             { "$ref": "#/definitions/custom_func" },
+                            { "$ref": "#/definitions/custom_parse" },
                             { "$ref": "#/definitions/array" },
                             { "$ref": "#/definitions/template" }
                         ]
@@ -118,14 +123,20 @@
             "required": [ "name", "args" ],
             "additionalProperties": false
         },
+        "value_custom_parse": {
+            "type": "string",
+            "minLength": 1,
+            "$comment": "custom_parse can not be empty string"
+        },
         "result_type": {
             "type": "string",
             "enum": [
-                "int",
-                "float",
+                "array",
                 "boolean",
-                "string",
-                "object"
+                "float",
+                "int",
+                "object",
+                "string"
             ]
         },
         "const": {
@@ -188,6 +199,7 @@
                             { "$ref": "#/definitions/field" },
                             { "$ref": "#/definitions/object" },
                             { "$ref": "#/definitions/custom_func" },
+                            { "$ref": "#/definitions/custom_parse" },
                             { "$ref": "#/definitions/template" }
                         ],
                         "$comment": "array's element can be any kind of transform, except array. might support in the future, but not now"
@@ -222,6 +234,20 @@
                 "_comment": { "$ref": "#/definitions/value_comment" }
             },
             "required": [ "custom_func" ],
+            "additionalProperties": false
+        },
+        "custom_parse": {
+            "type": "object",
+            "properties": {
+                "xpath": { "$ref": "#/definitions/value_xpath" },
+                "xpath_dynamic": { "$ref": "#/definitions/value_xpath_dynamic" },
+                "custom_parse": { "$ref": "#/definitions/value_custom_parse" },
+                "result_type": { "$ref": "#/definitions/result_type" },
+                "keep_leading_trailing_space": { "$ref": "#/definitions/value_keep_leading_trailing_space" },
+                "keep_empty_or_null": { "$ref": "#/definitions/value_keep_empty_or_null" },
+                "_comment": { "$ref": "#/definitions/value_comment" }
+            },
+            "required": [ "custom_parse" ],
             "additionalProperties": false
         }
     }

--- a/omniparser/schemavalidate/transformDeclarations.go
+++ b/omniparser/schemavalidate/transformDeclarations.go
@@ -21,6 +21,7 @@ const (
                         { "$ref": "#/definitions/field" },
                         { "$ref": "#/definitions/object" },
                         { "$ref": "#/definitions/custom_func" },
+                        { "$ref": "#/definitions/custom_parse" },
                         { "$ref": "#/definitions/array" },
                         { "$ref": "#/definitions/template" }
                     ]
@@ -34,6 +35,7 @@ const (
                         { "$ref": "#/definitions/field" },
                         { "$ref": "#/definitions/object" },
                         { "$ref": "#/definitions/custom_func" },
+                        { "$ref": "#/definitions/custom_parse" },
                         { "$ref": "#/definitions/array" },
                         { "$ref": "#/definitions/template" }
                     ]
@@ -76,6 +78,7 @@ const (
                     { "$ref": "#/definitions/external" },
                     { "$ref": "#/definitions/field" },
                     { "$ref": "#/definitions/custom_func" },
+                    { "$ref": "#/definitions/custom_parse" },
                     { "$ref": "#/definitions/template" }
                 ]
             }
@@ -95,6 +98,7 @@ const (
                         { "$ref": "#/definitions/field" },
                         { "$ref": "#/definitions/object" },
                         { "$ref": "#/definitions/custom_func" },
+                        { "$ref": "#/definitions/custom_parse" },
                         { "$ref": "#/definitions/array" },
                         { "$ref": "#/definitions/template" }
                     ],
@@ -115,6 +119,7 @@ const (
                             { "$ref": "#/definitions/external" },
                             { "$ref": "#/definitions/field" },
                             { "$ref": "#/definitions/custom_func" },
+                            { "$ref": "#/definitions/custom_parse" },
                             { "$ref": "#/definitions/array" },
                             { "$ref": "#/definitions/template" }
                         ]
@@ -125,14 +130,20 @@ const (
             "required": [ "name", "args" ],
             "additionalProperties": false
         },
+        "value_custom_parse": {
+            "type": "string",
+            "minLength": 1,
+            "$comment": "custom_parse can not be empty string"
+        },
         "result_type": {
             "type": "string",
             "enum": [
-                "int",
-                "float",
+                "array",
                 "boolean",
-                "string",
-                "object"
+                "float",
+                "int",
+                "object",
+                "string"
             ]
         },
         "const": {
@@ -195,6 +206,7 @@ const (
                             { "$ref": "#/definitions/field" },
                             { "$ref": "#/definitions/object" },
                             { "$ref": "#/definitions/custom_func" },
+                            { "$ref": "#/definitions/custom_parse" },
                             { "$ref": "#/definitions/template" }
                         ],
                         "$comment": "array's element can be any kind of transform, except array. might support in the future, but not now"
@@ -229,6 +241,20 @@ const (
                 "_comment": { "$ref": "#/definitions/value_comment" }
             },
             "required": [ "custom_func" ],
+            "additionalProperties": false
+        },
+        "custom_parse": {
+            "type": "object",
+            "properties": {
+                "xpath": { "$ref": "#/definitions/value_xpath" },
+                "xpath_dynamic": { "$ref": "#/definitions/value_xpath_dynamic" },
+                "custom_parse": { "$ref": "#/definitions/value_custom_parse" },
+                "result_type": { "$ref": "#/definitions/result_type" },
+                "keep_leading_trailing_space": { "$ref": "#/definitions/value_keep_leading_trailing_space" },
+                "keep_empty_or_null": { "$ref": "#/definitions/value_keep_empty_or_null" },
+                "_comment": { "$ref": "#/definitions/value_comment" }
+            },
+            "required": [ "custom_parse" ],
             "additionalProperties": false
         }
     }

--- a/samples/omniv2/customparse/.snapshots/TestSample
+++ b/samples/omniv2/customparse/.snapshots/TestSample
@@ -1,0 +1,67 @@
+[
+	{
+		"business_details": {
+			"reviews": [
+				{
+					"rating": "Exceeded Expectation",
+					"year": 2020
+				},
+				{
+					"rating": "Met Expectation",
+					"year": 2019
+				},
+				{
+					"rating": "Below Expectation",
+					"year": 2018
+				}
+			],
+			"title": "Sr. Engineer (1234)",
+			"years_of_service": 3
+		},
+		"employee_id": "1234",
+		"personal_details": {
+			"age": 20,
+			"home_address": {
+				"city": "city-1234",
+				"state": "state-1234",
+				"street": "street-1234",
+				"zip": "1234"
+			},
+			"name": "name-1234"
+		},
+		"team": "TEAM-1234"
+	},
+	{
+		"business_details": {
+			"reviews": [
+				{
+					"rating": "Exceeded Expectation",
+					"year": 2020
+				},
+				{
+					"rating": "Met Expectation",
+					"year": 2019
+				},
+				{
+					"rating": "Below Expectation",
+					"year": 2018
+				}
+			],
+			"title": "Sr. Engineer (5678)",
+			"years_of_service": 3
+		},
+		"employee_id": "5678",
+		"personal_details": {
+			"age": 20,
+			"home_address": {
+				"city": "city-5678",
+				"state": "state-5678",
+				"street": "street-5678",
+				"zip": "5678"
+			},
+			"name": "name-5678"
+		},
+		"team": "TEAM-5678"
+	}
+]
+

--- a/samples/omniv2/customparse/.snapshots/TestSample
+++ b/samples/omniv2/customparse/.snapshots/TestSample
@@ -20,7 +20,7 @@
 		},
 		"employee_id": "1234",
 		"personal_details": {
-			"age": 20,
+			"age": 55,
 			"home_address": {
 				"city": "city-1234",
 				"state": "state-1234",
@@ -52,7 +52,7 @@
 		},
 		"employee_id": "5678",
 		"personal_details": {
-			"age": 20,
+			"age": 59,
 			"home_address": {
 				"city": "city-5678",
 				"state": "state-5678",

--- a/samples/omniv2/customparse/sample.xml
+++ b/samples/omniv2/customparse/sample.xml
@@ -1,0 +1,10 @@
+<Employees>
+    <Employee>
+        <ID>1234</ID>
+        <Team>HR</Team>
+    </Employee>
+    <Employee>
+        <ID>5678</ID>
+        <Team>DevOps</Team>
+    </Employee>
+</Employees>

--- a/samples/omniv2/customparse/sample_schema.json
+++ b/samples/omniv2/customparse/sample_schema.json
@@ -1,0 +1,14 @@
+{
+    "parser_settings": {
+        "version": "omni.2.0",
+        "file_format_type": "xml"
+    },
+    "transform_declarations": {
+        "FINAL_OUTPUT": { "xpath": "/Employees/Employee", "object": {
+            "employee_id": { "xpath": "ID" },
+            "personal_details": { "xpath": "ID", "custom_parse": "employee_personal_details_lookup" },
+            "business_details": { "xpath": "ID", "custom_parse": "employee_business_details_lookup" },
+            "team": { "xpath": "ID", "custom_parse": "employee_team_lookup" }
+        }}
+    }
+}

--- a/samples/omniv2/customparse/sample_test.go
+++ b/samples/omniv2/customparse/sample_test.go
@@ -1,0 +1,117 @@
+package customparse
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	node "github.com/antchfx/xmlquery"
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/jsons"
+	"github.com/jf-tech/omniparser/omniparser"
+	omniv2 "github.com/jf-tech/omniparser/omniparser/schemaplugin/omni/v2"
+	"github.com/jf-tech/omniparser/omniparser/schemaplugin/omni/v2/transform"
+	"github.com/jf-tech/omniparser/omniparser/transformctx"
+)
+
+func TestSample(t *testing.T) {
+	schemaFile := "./sample_schema.json"
+	schemaFileBaseName := filepath.Base(schemaFile)
+	schemaFileReader, err := os.Open(schemaFile)
+	assert.NoError(t, err)
+	defer schemaFileReader.Close()
+
+	inputFile := "./sample.xml"
+	inputFileBaseName := filepath.Base(inputFile)
+	inputFileReader, err := os.Open(inputFile)
+	assert.NoError(t, err)
+	defer inputFileReader.Close()
+
+	parser, err := omniparser.NewParser(
+		schemaFileBaseName,
+		schemaFileReader,
+		omniparser.SchemaPluginConfig{
+			ParseSchema: omniv2.ParseSchema,
+			PluginParams: &omniv2.PluginParams{
+				CustomParseFuncs: transform.CustomParseFuncs{
+					"employee_personal_details_lookup": employeePersonalDetailsLookup,
+					"employee_business_details_lookup": employeeBusinessDetailsLookup,
+					"employee_team_lookup":             employeeTempLookup,
+				},
+			},
+		})
+	assert.NoError(t, err)
+	op, err := parser.GetTransformOp(
+		inputFileBaseName,
+		inputFileReader,
+		&transformctx.Ctx{})
+	assert.NoError(t, err)
+
+	var records []string
+	for op.Next() {
+		recordBytes, err := op.Read()
+		assert.NoError(t, err)
+		records = append(records, string(recordBytes))
+	}
+	cupaloy.SnapshotT(t, jsons.BPJ("["+strings.Join(records, ",")+"]"))
+}
+
+// Pretend we need to do some secure database look-up for employee's various info based on id.
+// The result can be one of these:
+// - you can directly return a string value, if this lookup yields a simple string value.
+// - you can return a generic map[string]interface{}, if lookup yields a complex structure.
+// - you can return a struct that is JSON marshalable, if lookup yields a complex structure.
+
+// These are very contrived examples, only for illustration purposes.
+func employeePersonalDetailsLookup(_ *transformctx.Ctx, node *node.Node) (interface{}, error) {
+	id := node.InnerText()
+	// Pretend some complex logic and/or RPC calls...
+	// This custom_parse demonstrates how to return a complex object with map[string]interface{}
+	return map[string]interface{}{
+		"name": "name-" + id,
+		"age":  time.Now().Nanosecond()%50 + 20,
+		"home_address": map[string]interface{}{
+			"street": "street-" + id,
+			"city":   "city-" + id,
+			"state":  "state-" + id,
+			"zip":    id,
+		},
+	}, nil
+}
+
+func employeeBusinessDetailsLookup(_ *transformctx.Ctx, node *node.Node) (interface{}, error) {
+	id := node.InnerText()
+	// Pretend some complex logic and/or RPC calls...
+	// This custom_parse demonstrates how to return a complex object with golang struct
+	type employeeReview struct {
+		Year   int    `json:"year"`
+		Rating string `json:"rating"`
+	}
+	type employeeBusinessDetails struct {
+		Title          string           `json:"title"`
+		YearsOfService int              `json:"years_of_service"`
+		Reviews        []employeeReview `json:"reviews"`
+	}
+	return employeeBusinessDetails{
+		Title:          "Sr. Engineer (" + id + ")",
+		YearsOfService: 3,
+		Reviews: []employeeReview{
+			{Year: 2020, Rating: "Exceeded Expectation"},
+			{Year: 2019, Rating: "Met Expectation"},
+			{Year: 2018, Rating: "Below Expectation"},
+		},
+	}, nil
+}
+
+func employeeTempLookup(_ *transformctx.Ctx, node *node.Node) (interface{}, error) {
+	id := node.InnerText()
+	// Pretend some complex logic and/or RPC calls...
+	// This custom_parse demonstrates how to return a single string value.
+	// You can also in schema specify different result_type (such as int, float64) to
+	// fit your needs.
+	return "TEAM-" + id, nil
+}

--- a/samples/omniv2/customparse/sample_test.go
+++ b/samples/omniv2/customparse/sample_test.go
@@ -3,9 +3,9 @@ package customparse
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	node "github.com/antchfx/xmlquery"
 	"github.com/bradleyjkemp/cupaloy"
@@ -71,9 +71,13 @@ func employeePersonalDetailsLookup(_ *transformctx.Ctx, node *node.Node) (interf
 	id := node.InnerText()
 	// Pretend some complex logic and/or RPC calls...
 	// This custom_parse demonstrates how to return a complex object with map[string]interface{}
+	idInt, err := strconv.Atoi(id)
+	if err != nil {
+		return nil, err
+	}
 	return map[string]interface{}{
 		"name": "name-" + id,
-		"age":  time.Now().Nanosecond()%50 + 20,
+		"age":  idInt%40 + 21, // whatever this means :)
 		"home_address": map[string]interface{}{
 			"street": "street-" + id,
 			"city":   "city-" + id,


### PR DESCRIPTION
`custom_parse` is an ability to extend omniv2 plugin's `parseNode` so we can do a custom *Node -> JSON transform.

Added `samples/omniv2/customparse/` for usage illustration.