### PR TITLE
Introduce `dateTimeToRFC3339` and `dateTimeLayoutToRFC3339` custom_func

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.14-alpine
 WORKDIR /omniparser
 COPY . .
-RUN mkdir bin
 RUN go build -o omniparser/cli/op omniparser/cli/op.go
 RUN omniparser/cli/op --help
 CMD omniparser/cli/op server

--- a/omniparser/customfuncs/.snapshots/TestDumpBuiltinCustomFuncNames
+++ b/omniparser/customfuncs/.snapshots/TestDumpBuiltinCustomFuncNames
@@ -1,0 +1,17 @@
+[
+	"avg",
+	"concat",
+	"dateTimeLayoutToRFC3339",
+	"dateTimeToRFC3339",
+	"dateTimeToRfc3339",
+	"dateTimeWithLayoutToRfc3339",
+	"eval",
+	"external",
+	"floor",
+	"javascript",
+	"lower",
+	"splitIntoJsonArray",
+	"substring",
+	"sum",
+	"upper"
+]

--- a/omniparser/customfuncs/customFuncs.go
+++ b/omniparser/customfuncs/customFuncs.go
@@ -19,22 +19,6 @@ type CustomFuncType = interface{}
 // CustomFuncs is a map from custom func names to an actual custom func.
 type CustomFuncs = map[string]CustomFuncType
 
-// BuiltinCustomFuncs contains all the built-in custom functions.
-var BuiltinCustomFuncs = map[string]CustomFuncType{
-	// keep these custom funcs lexically sorted
-	"avg":                avg,
-	"concat":             concat,
-	"eval":               eval, // deprecated; kept for backcompat reason; use 'javascript' instead.
-	"external":           external,
-	"floor":              floor,
-	"javascript":         javascript,
-	"lower":              lower,
-	"splitIntoJsonArray": splitIntoJsonArray,
-	"substring":          substring,
-	"sum":                sum,
-	"upper":              upper,
-}
-
 // Merge merges multiple custom func maps into one.
 func Merge(funcs ...CustomFuncs) CustomFuncs {
 	merged := make(CustomFuncs)
@@ -45,6 +29,32 @@ func Merge(funcs ...CustomFuncs) CustomFuncs {
 	}
 	return merged
 }
+
+var builtinPublishedCustomFuncs = map[string]CustomFuncType{
+	// keep these custom funcs lexically sorted
+	"avg":                     avg,
+	"concat":                  concat,
+	"dateTimeToRFC3339":       dateTimeToRFC3339,
+	"dateTimeLayoutToRFC3339": dateTimeLayoutToRFC3339,
+	"floor":                   floor,
+	"javascript":              javascript,
+	"lower":                   lower,
+	"substring":               substring,
+	"sum":                     sum,
+	"upper":                   upper,
+}
+
+var builtinHiddenBackCompatCustomFuncs = map[string]CustomFuncType{
+	// keep these custom funcs lexically sorted
+	"dateTimeToRfc3339":           dateTimeToRFC3339,       // deprecated; use dateTimeToRFC3339.
+	"dateTimeWithLayoutToRfc3339": dateTimeLayoutToRFC3339, // deprecated; use dateTimeLayoutToRFC3339.
+	"eval":                        eval,                    // deprecated; use 'javascript'.
+	"external":                    external,                // deprecated; use "external" decl.
+	"splitIntoJsonArray":          splitIntoJsonArray,      // deprecated; use 'javascript'.
+}
+
+// BuiltinCustomFuncs contains all the built-in custom functions.
+var BuiltinCustomFuncs = Merge(builtinPublishedCustomFuncs, builtinHiddenBackCompatCustomFuncs)
 
 func concat(_ *transformctx.Ctx, strs ...string) (string, error) {
 	var b bytes.Buffer

--- a/omniparser/customfuncs/customFuncs_test.go
+++ b/omniparser/customfuncs/customFuncs_test.go
@@ -1,14 +1,25 @@
 package customfuncs
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/bradleyjkemp/cupaloy"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/jf-tech/omniparser/jsons"
 	"github.com/jf-tech/omniparser/omniparser/transformctx"
 	"github.com/jf-tech/omniparser/strs"
 )
 
+func TestDumpBuiltinCustomFuncNames(t *testing.T) {
+	var names []string
+	for name := range BuiltinCustomFuncs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	cupaloy.SnapshotT(t, jsons.BPM(names))
+}
 func TestMerge(t *testing.T) {
 	fs1 := CustomFuncs{
 		"a": 1,

--- a/omniparser/customfuncs/datetime.go
+++ b/omniparser/customfuncs/datetime.go
@@ -1,0 +1,86 @@
+package customfuncs
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/jf-tech/omniparser/omniparser/transformctx"
+	"github.com/jf-tech/omniparser/times"
+)
+
+const (
+	rfc3339NoTZ = "2006-01-02T15:04:05"
+)
+
+// normalizeToRFC3339 parse in an input datetime string and normalizes it into RFC3339 standard format.
+//
+// If layout is specific, then normalizeToRFC3339 will parse datetime string using the supplied layout;
+// otherwise, it will default to times.SmartParse.
+//
+// If datetime string contains tz info in it (such as 'Z', or '-America/New_York' etc, or '-0700', etc)
+// then fromTZ is IGNORED. Otherwise, then datetime string will be parsed in with its face value y/m/d/h/m/s
+// and bonded with the fromTZ, if fromTZ isn't "".
+//
+// Once datetime is parsed (and fromTZ bonded if needed), then it will be converted into toTZ, if toTZ isn't
+// "".
+//
+// Finally it will be formatted into RFC3339.
+func normalizeToRFC3339(datetime, layout string, layoutHasTZ bool, fromTZ, toTZ string) (string, error) {
+	if datetime == "" {
+		return "", nil
+	}
+	var t time.Time
+	var hasTZ bool
+	var err error
+	if layout == "" {
+		t, hasTZ, err = times.SmartParse(datetime)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		t, err = time.Parse(layout, datetime)
+		if err != nil {
+			return "", err
+		}
+		hasTZ = layoutHasTZ
+	}
+	// Only use fromTZ if the original t doesn't have tz info baked in.
+	if !hasTZ && fromTZ != "" {
+		t, err = times.OverwriteTZ(t, fromTZ)
+		if err != nil {
+			return "", err
+		}
+		hasTZ = true
+	}
+	if toTZ != "" {
+		if hasTZ {
+			t, err = times.ConvertTZ(t, toTZ)
+		} else {
+			t, err = times.OverwriteTZ(t, toTZ)
+			hasTZ = true
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+	if hasTZ {
+		return t.Format(time.RFC3339), nil
+	}
+	return t.Format(rfc3339NoTZ), nil
+}
+
+func dateTimeToRFC3339(_ *transformctx.Ctx, datetime, fromTZ, toTZ string) (string, error) {
+	return normalizeToRFC3339(datetime, "", false, fromTZ, toTZ)
+}
+
+func dateTimeLayoutToRFC3339(_ *transformctx.Ctx, datetime, layout, layoutTZ, fromTZ, toTZ string) (string, error) {
+	layoutTZFlag := false
+	if layout != "" && layoutTZ != "" {
+		var err error
+		layoutTZFlag, err = strconv.ParseBool(layoutTZ)
+		if err != nil {
+			return "", err
+		}
+	}
+	return normalizeToRFC3339(datetime, layout, layoutTZFlag, fromTZ, toTZ)
+}

--- a/omniparser/customfuncs/datetime_test.go
+++ b/omniparser/customfuncs/datetime_test.go
@@ -1,0 +1,194 @@
+package customfuncs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateTimeToRFC3339(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		datetime string
+		fromTZ   string
+		toTZ     string
+		err      string
+		expected string
+	}{
+		{
+			name:     "empty datetime -> no op",
+			datetime: "",
+			fromTZ:   "UTC",
+			toTZ:     "America/New_York",
+			err:      "",
+			expected: "",
+		},
+		{
+			name:     "invalid datetime",
+			datetime: "invalid",
+			fromTZ:   "UTC",
+			toTZ:     "America/New_York",
+			err:      "unable to parse 'invalid' in any supported date/time format",
+			expected: "",
+		},
+		{
+			name:     "invalid fromTZ",
+			datetime: "2020/09/22T12:34:56",
+			fromTZ:   "invalid",
+			toTZ:     "America/New_York",
+			err:      "unknown time zone invalid",
+			expected: "",
+		},
+		{
+			name:     "invalid toTZ",
+			datetime: "2020/09/22T12:34:56",
+			fromTZ:   "UTC",
+			toTZ:     "invalid",
+			err:      "unknown time zone invalid",
+			expected: "",
+		},
+		{
+			name:     "datetime no tz; no fromTZ; no toTZ -> result no tz",
+			datetime: "2020/09/22T12:34:56",
+			fromTZ:   "",
+			toTZ:     "",
+			err:      "",
+			expected: "2020-09-22T12:34:56",
+		},
+		{
+			name:     "datetime no tz; no fromTZ; with toTZ -> result direct use toTZ",
+			datetime: "2020/09/22T12:34:56",
+			fromTZ:   "",
+			toTZ:     "America/New_York",
+			err:      "",
+			expected: "2020-09-22T12:34:56-04:00",
+		},
+		{
+			name:     "datetime no tz; with fromTZ; no toTZ -> result direct use fromTZ",
+			datetime: "2020/09/22T12:34:56",
+			fromTZ:   "America/Los_Angeles",
+			toTZ:     "",
+			err:      "",
+			expected: "2020-09-22T12:34:56-07:00",
+		},
+		{
+			name:     "datetime no tz; with fromTZ; with toTZ -> datetime + fromTZ then converts to toTZ",
+			datetime: "2020/09/22T12:34:56",
+			fromTZ:   "America/Los_Angeles",
+			toTZ:     "America/New_York",
+			err:      "",
+			expected: "2020-09-22T15:34:56-04:00",
+		},
+		{
+			name:     "datetime with tz; no fromTZ; no toTZ -> result is datetime with tz",
+			datetime: "2020/09/22T12:34:56-05",
+			fromTZ:   "",
+			toTZ:     "",
+			err:      "",
+			expected: "2020-09-22T12:34:56-05:00",
+		},
+		{
+			name:     "datetime with tz; no fromTZ; with toTZ -> datetime with tz converts to toTZ",
+			datetime: "2020/09/22T12:34:56-05",
+			fromTZ:   "",
+			toTZ:     "America/New_York",
+			err:      "",
+			expected: "2020-09-22T13:34:56-04:00",
+		},
+		{
+			name:     "datetime with tz; with fromTZ; no toTZ -> fromTZ ignored",
+			datetime: "2020/09/22T12:34:56-05",
+			fromTZ:   "America/Los_Angeles",
+			toTZ:     "",
+			err:      "",
+			expected: "2020-09-22T12:34:56-05:00",
+		},
+		{
+			name:     "datetime with tz; with fromTZ; with toTZ -> fromTZ ignored, datetime with tz converts to toTZ",
+			datetime: "2020/09/22T12:34:56-05",
+			fromTZ:   "America/Los_Angeles",
+			toTZ:     "America/New_York",
+			err:      "",
+			expected: "2020-09-22T13:34:56-04:00",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := dateTimeToRFC3339(nil, test.datetime, test.fromTZ, test.toTZ)
+			if test.err != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+				assert.Equal(t, "", result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, result)
+			}
+		})
+	}
+}
+
+func TestDateTimeLayoutToRFC3339(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		datetime string
+		layout   string
+		layoutTZ string
+		fromTZ   string
+		toTZ     string
+		err      string
+		expected string
+	}{
+		{
+			name:     "layout but no tz",
+			datetime: "2020+09+22 X 12:34:56",
+			layout:   "2006+01+02 X 15:04:05",
+			layoutTZ: "false",
+			fromTZ:   "America/Los_Angeles",
+			toTZ:     "America/New_York",
+			err:      "",
+			expected: "2020-09-22T15:34:56-04:00",
+		},
+		{
+			name:     "layout with tz",
+			datetime: "2020+09+22 X 12:34:56 +02",
+			layout:   "2006+01+02 X 15:04:05 -07",
+			layoutTZ: "true",
+			fromTZ:   "",
+			toTZ:     "America/Chicago",
+			err:      "",
+			expected: "2020-09-22T05:34:56-05:00",
+		},
+		{
+			name:     "invalid layoutTZ flag",
+			datetime: "",
+			layout:   "whatever",
+			layoutTZ: "not a bool value",
+			fromTZ:   "",
+			toTZ:     "",
+			err:      `strconv.ParseBool: parsing "not a bool value": invalid syntax`,
+			expected: "",
+		},
+		{
+			name:     "layout parsing failed",
+			datetime: "not valid",
+			layout:   "2006/01/02 15:04:05",
+			layoutTZ: "false",
+			fromTZ:   "",
+			toTZ:     "",
+			err:      `parsing time "not valid" as "2006/01/02 15:04:05": cannot parse "not valid" as "2006"`,
+			expected: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := dateTimeLayoutToRFC3339(
+				nil, test.datetime, test.layout, test.layoutTZ, test.fromTZ, test.toTZ)
+			if test.err != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+				assert.Equal(t, "", result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, result)
+			}
+		})
+	}
+}

--- a/samples/omniv2/xml/.snapshots/Test1_DateTime_Parse_And_Format
+++ b/samples/omniv2/xml/.snapshots/Test1_DateTime_Parse_And_Format
@@ -1,0 +1,15 @@
+[
+	{
+		"custom_layout_day_before_month": "2020-09-21T17:34:56-07:00",
+		"iana_tz_date_time": "2020-09-22T12:34:56-04:00",
+		"iana_tz_date_time_use_to_tz": "2020-09-22T09:34:56-07:00",
+		"no_tz_date": "2020-09-22T00:00:00",
+		"no_tz_date_time": "2020-09-22T12:34:56",
+		"no_tz_date_time_use_both_from_and_to_tz": "2020-09-22T09:34:56-07:00",
+		"no_tz_date_time_use_from_tz": "2020-09-22T12:34:56-04:00",
+		"no_tz_date_time_use_to_tz": "2020-09-22T12:34:56-07:00",
+		"utc_date_time": "2020-09-22T12:34:56Z",
+		"utc_date_time_from_tz_ignored": "2020-09-22T12:34:56Z",
+		"utc_date_time_use_to_tz": "2020-09-22T07:34:56-05:00"
+	}
+]

--- a/samples/omniv2/xml/1_datetime_parse_and_format.input.xml
+++ b/samples/omniv2/xml/1_datetime_parse_and_format.input.xml
@@ -1,0 +1,7 @@
+<Root>
+    <JustDate>2020/09/22</JustDate>
+    <DateTimeWithNoTZ>09/22/2020 12:34:56</DateTimeWithNoTZ>
+    <DateTimeUTC>09-22-2020  12:34:56Z</DateTimeUTC>
+    <DateTimeWithIANA_TZ>09/22/20T12:34:56-America/New_York</DateTimeWithIANA_TZ>
+    <DayBeforeMonthWithTZAbbreviation>22/09/20T12:34:56-NZST</DayBeforeMonthWithTZAbbreviation>
+</Root>

--- a/samples/omniv2/xml/1_datetime_parse_and_format.input.xml
+++ b/samples/omniv2/xml/1_datetime_parse_and_format.input.xml
@@ -3,5 +3,5 @@
     <DateTimeWithNoTZ>09/22/2020 12:34:56</DateTimeWithNoTZ>
     <DateTimeUTC>09-22-2020  12:34:56Z</DateTimeUTC>
     <DateTimeWithIANA_TZ>09/22/20T12:34:56-America/New_York</DateTimeWithIANA_TZ>
-    <DayBeforeMonthWithTZAbbreviation>22/09/20T12:34:56-NZST</DayBeforeMonthWithTZAbbreviation>
+    <DayBeforeMonth>22/09/20T12:34:56</DayBeforeMonth>
 </Root>

--- a/samples/omniv2/xml/1_datetime_parse_and_format.schema.json
+++ b/samples/omniv2/xml/1_datetime_parse_and_format.schema.json
@@ -92,10 +92,10 @@
             "custom_layout_day_before_month": { "custom_func": {
                 "name": "dateTimeLayoutToRFC3339",
                 "args": [
-                    { "xpath": "DayBeforeMonthWithTZAbbreviation" },
-                    { "const": "02/01/06T15:04:05-MST", "_comment": "layout" },
-                    { "const": "true", "_comment": "layoutTZ" },
-                    { "const": "", "_comment": "fromTZ" },
+                    { "xpath": "DayBeforeMonth" },
+                    { "const": "02/01/06T15:04:05", "_comment": "layout" },
+                    { "const": "false", "_comment": "layoutTZ" },
+                    { "const": "Pacific/Auckland", "_comment": "fromTZ" },
                     { "const": "America/Los_Angeles", "_comment": "toTZ" }
                 ]
             }}

--- a/samples/omniv2/xml/1_datetime_parse_and_format.schema.json
+++ b/samples/omniv2/xml/1_datetime_parse_and_format.schema.json
@@ -1,0 +1,104 @@
+{
+    "parser_settings": {
+        "version": "omni.2.0",
+        "file_format_type": "xml"
+    },
+    "transform_declarations": {
+        "FINAL_OUTPUT": { "xpath": ".", "object": {
+            "no_tz_date": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "JustDate" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "", "_comment": "toTZ" }
+                ]
+            }},
+
+            "no_tz_date_time": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeWithNoTZ" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "", "_comment": "toTZ" }
+                ]
+            }},
+            "no_tz_date_time_use_from_tz": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeWithNoTZ" },
+                    { "const": "America/New_York", "_comment": "fromTZ" },
+                    { "const": "", "_comment": "toTZ" }
+                ]
+            }},
+            "no_tz_date_time_use_to_tz": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeWithNoTZ" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "America/Los_Angeles", "_comment": "toTZ" }
+                ]
+            }},
+            "no_tz_date_time_use_both_from_and_to_tz": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeWithNoTZ" },
+                    { "const": "America/New_York", "_comment": "fromTZ" },
+                    { "const": "America/Los_Angeles", "_comment": "toTZ" }
+                ]
+            }},
+
+            "utc_date_time": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeUTC" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "", "_comment": "toTZ" }
+                ]
+            }},
+            "utc_date_time_from_tz_ignored": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeUTC" },
+                    { "const": "America/Chicago", "_comment": "fromTZ" },
+                    { "const": "", "_comment": "toTZ" }
+                ]
+            }},
+            "utc_date_time_use_to_tz": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeUTC" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "America/Chicago", "_comment": "toTZ" }
+                ]
+            }},
+
+            "iana_tz_date_time": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeWithIANA_TZ" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "", "_comment": "toTZ" }
+                ]
+            }},
+            "iana_tz_date_time_use_to_tz": { "custom_func": {
+                "name": "dateTimeToRfc3339",
+                "args": [
+                    { "xpath": "DateTimeWithIANA_TZ" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "America/Los_Angeles", "_comment": "toTZ" }
+                ]
+            }},
+
+            "custom_layout_day_before_month": { "custom_func": {
+                "name": "dateTimeLayoutToRFC3339",
+                "args": [
+                    { "xpath": "DayBeforeMonthWithTZAbbreviation" },
+                    { "const": "02/01/06T15:04:05-MST", "_comment": "layout" },
+                    { "const": "true", "_comment": "layoutTZ" },
+                    { "const": "", "_comment": "fromTZ" },
+                    { "const": "America/Los_Angeles", "_comment": "toTZ" }
+                ]
+            }}
+        }}
+    }
+}

--- a/samples/omniv2/xml/xml_test.go
+++ b/samples/omniv2/xml/xml_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/jf-tech/omniparser/samples/sampleutil"
 )
 
+func Test1_DateTime_Parse_And_Format(t *testing.T) {
+	cupaloy.SnapshotT(t, jsons.BPJ(sampleutil.SampleTestCommon(
+		t, "./1_datetime_parse_and_format.schema.json", "./1_datetime_parse_and_format.input.xml")))
+}
+
 func Test2_Multiple_Objects(t *testing.T) {
 	cupaloy.SnapshotT(t, jsons.BPJ(sampleutil.SampleTestCommon(
 		t, "./2_multiple_objects.schema.json", "./2_multiple_objects.input.xml")))

--- a/times/util.go
+++ b/times/util.go
@@ -1,0 +1,36 @@
+package times
+
+import (
+	"time"
+
+	"github.com/jf-tech/omniparser/strs"
+)
+
+// OverwriteTZ takes the literal values of y/m/d/h/m/s of a time.Time and uses them
+// together with a supplied timezone to form a new time.Time, effectively "overwriting"
+// the original time.Time's tz. If tz is empty, the original time.Time is returned.
+func OverwriteTZ(t time.Time, tz string) (time.Time, error) {
+	if !strs.IsStrNonBlank(tz) {
+		return t, nil
+	}
+	loc, err := loadLoc(tz)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc), nil
+}
+
+// ConvertTZ converts a time.Time into a new time.Time in a timezone specified by tz.
+// This is unlike OverwriteTZ, where its tz is overwritten, resulting in a completely
+// different point of time: ConvertTZ keeps the point of time unchanged - it merely
+// switches the input time.Time to a different timezone.
+func ConvertTZ(t time.Time, tz string) (time.Time, error) {
+	if !strs.IsStrNonBlank(tz) {
+		return t, nil
+	}
+	loc, err := loadLoc(tz)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t.In(loc), nil
+}

--- a/times/util_test.go
+++ b/times/util_test.go
@@ -1,0 +1,116 @@
+package times
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverwriteTZ(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    string
+		tz       string
+		err      string
+		expected string
+	}{
+		{
+			name:     "empty tz -> no op",
+			input:    "2019/07/18T12:34:56-0700",
+			tz:       "",
+			err:      "",
+			expected: "2019-07-18T12:34:56-07:00",
+		},
+		{
+			name:     "datetime w/o tz -> America/Los_Angeles",
+			input:    "2019/07/18T12:34:56",
+			tz:       "America/Los_Angeles",
+			err:      "",
+			expected: "2019-07-18T12:34:56-07:00",
+		},
+		{
+			name:     "datetime w/ tz -> America/Los_Angeles",
+			input:    "2019/07/18T12:34:56+05",
+			tz:       "America/Los_Angeles",
+			err:      "",
+			expected: "2019-07-18T12:34:56-07:00",
+		},
+		{
+			name:     "invalid tz",
+			input:    "2019/07/18T12:34:56+05",
+			tz:       "invalid",
+			err:      "unknown time zone invalid",
+			expected: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t1, _, err := SmartParse(test.input)
+			assert.NoError(t, err)
+			t2, err := OverwriteTZ(t1, test.tz)
+			if test.err != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+				assert.Equal(t, time.Time{}, t2)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, t2.Format(time.RFC3339))
+			}
+		})
+	}
+}
+
+func TestConvertTZ(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    string
+		tz       string
+		err      string
+		expected string
+	}{
+		{
+			name:     "empty tz -> no op",
+			input:    "2019/07/18T12:34:56-0700",
+			tz:       "",
+			err:      "",
+			expected: "2019-07-18T12:34:56-07:00",
+		},
+		{
+			// even though input has no tz, but SmartParse (and time.Parse)
+			// will assign UTC to it by default.
+			name:     "datetime w/o tz -> America/Los_Angeles",
+			input:    "2019/07/18T12:34:56",
+			tz:       "America/Los_Angeles",
+			err:      "",
+			expected: "2019-07-18T05:34:56-07:00",
+		},
+		{
+			name:     "datetime w/ tz -> America/Los_Angeles",
+			input:    "2019/07/18T12:34:56+05",
+			tz:       "America/Los_Angeles",
+			err:      "",
+			expected: "2019-07-18T00:34:56-07:00",
+		},
+		{
+			name:     "invalid tz",
+			input:    "2019/07/18T12:34:56+05",
+			tz:       "invalid",
+			err:      "unknown time zone invalid",
+			expected: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t1, _, err := SmartParse(test.input)
+			assert.NoError(t, err)
+			t2, err := ConvertTZ(t1, test.tz)
+			if test.err != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+				assert.Equal(t, time.Time{}, t2)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, t2.Format(time.RFC3339))
+			}
+		})
+	}
+}


### PR DESCRIPTION
These two functions are ones of the most frequently used custom_funcs that normalize input date time string into standard RFC3339 format with complex timezone conversion rules taken care of.

Add an XML sample to illustrate the usage.