### PR TITLE
Adding CSV reader.

### DIFF
--- a/errs/errs.go
+++ b/errs/errs.go
@@ -2,14 +2,10 @@ package errs
 
 import (
 	"errors"
-	"io"
 )
 
 // ErrSchemaNotSupported indicates a schema is not supported by a handler.
 var ErrSchemaNotSupported = errors.New("schema not supported")
-
-// ErrEOF indicates the end of input stream has reached.
-var ErrEOF = io.EOF
 
 // ErrTransformFailed indicates a particular record transform has failed. In general
 // this isn't fatal, and processing can continue.

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -1,6 +1,7 @@
 package errs
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,5 +10,5 @@ import (
 func TestIsErrTransformFailed(t *testing.T) {
 	assert.True(t, IsErrTransformFailed(ErrTransformFailed("test")))
 	assert.Equal(t, "test", ErrTransformFailed("test").Error())
-	assert.False(t, IsErrTransformFailed(ErrEOF))
+	assert.False(t, IsErrTransformFailed(io.EOF))
 }

--- a/handlers/omni/v2/fileformat/csv/decl.go
+++ b/handlers/omni/v2/fileformat/csv/decl.go
@@ -1,0 +1,25 @@
+package omniv2csv
+
+import (
+	"github.com/jf-tech/go-corelib/strs"
+)
+
+type column struct {
+	Name string `json:"name"`
+	// If the CSV column 'name' contains characters (such as space, or special letters) that are
+	// not suitable for *idr.Node construction and xpath query, this gives schema writer an
+	// alternate way to name/label the column. Optional.
+	Alias *string `json:"alias"`
+}
+
+func (c column) name() string {
+	return strs.StrPtrOrElse(c.Alias, c.Name)
+}
+
+type fileDecl struct {
+	Delimiter           string   `json:"delimiter"`
+	ReplaceDoubleQuotes bool     `json:"replace_double_quotes"`
+	HeaderRowIndex      *int     `json:"header_row_index"`
+	DataRowIndex        int      `json:"data_row_index"`
+	Columns             []column `json:"columns"`
+}

--- a/handlers/omni/v2/fileformat/csv/decl_test.go
+++ b/handlers/omni/v2/fileformat/csv/decl_test.go
@@ -1,0 +1,13 @@
+package omniv2csv
+
+import (
+	"testing"
+
+	"github.com/jf-tech/go-corelib/strs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColumnName(t *testing.T) {
+	assert.Equal(t, "name", column{Name: "name"}.name())
+	assert.Equal(t, "alias", column{Name: "name", Alias: strs.StrPtr("alias")}.name())
+}

--- a/handlers/omni/v2/fileformat/csv/reader.go
+++ b/handlers/omni/v2/fileformat/csv/reader.go
@@ -1,0 +1,156 @@
+package omniv2csv
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/antchfx/xpath"
+	"github.com/jf-tech/go-corelib/caches"
+	"github.com/jf-tech/go-corelib/ios"
+	"github.com/jf-tech/go-corelib/maths"
+
+	"github.com/jf-tech/omniparser/idr"
+)
+
+// ErrInvalidHeader indicates the header of the CSV input is corrupted, mismatched, or simply
+// unreadable. This is a fatal, non-continuable error.
+type ErrInvalidHeader string
+
+func (e ErrInvalidHeader) Error() string { return string(e) }
+
+// IsErrInvalidHeader checks if an err is of ErrInvalidHeader type.
+func IsErrInvalidHeader(err error) bool {
+	switch err.(type) {
+	case ErrInvalidHeader:
+		return true
+	default:
+		return false
+	}
+}
+
+type reader struct {
+	inputName     string
+	decl          *fileDecl
+	xpath         *xpath.Expr
+	r             *ios.LineNumReportingCsvReader
+	headerChecked bool
+}
+
+func (r *reader) Read() (*idr.Node, error) {
+	if !r.headerChecked {
+		err := r.checkHeader()
+		r.headerChecked = true
+		if err != nil {
+			return nil, err
+		}
+	}
+read:
+	record, err := r.r.Read()
+	if err == io.EOF {
+		return nil, io.EOF
+	}
+	if err != nil {
+		return nil, r.FmtErr("failed to fetch record: %s", err.Error())
+	}
+	n := r.recordToNode(record)
+	if r.xpath != nil && !idr.MatchAny(n, r.xpath) {
+		goto read
+	}
+	return n, nil
+}
+
+func (r *reader) checkHeader() error {
+	if r.decl.HeaderRowIndex == nil {
+		_ = r.jumpTo(r.decl.DataRowIndex - 1)
+		return nil
+	}
+	err := r.jumpTo(*r.decl.HeaderRowIndex - 1)
+	if err == io.EOF {
+		return ErrInvalidHeader(r.fmtErrStr("unable to read header: %s", err.Error()))
+	}
+	header, err := r.r.Read()
+	if err != nil {
+		return ErrInvalidHeader(r.fmtErrStr("unable to read header: %s", err.Error()))
+	}
+	if len(header) < len(r.decl.Columns) {
+		return ErrInvalidHeader(r.fmtErrStr(
+			"actual header column size (%d) is less than the size (%d) declared in file_declaration.columns in schema",
+			len(header), len(r.decl.Columns)))
+	}
+	for index, column := range r.decl.Columns {
+		if strings.TrimSpace(header[index]) != strings.TrimSpace(column.Name) {
+			return ErrInvalidHeader(r.fmtErrStr(
+				"header column[%d] '%s' does not match declared column name '%s' in schema",
+				index+1, strings.TrimSpace(header[index]), strings.TrimSpace(column.Name)))
+		}
+	}
+	_ = r.jumpTo(r.decl.DataRowIndex - 1)
+	return nil
+}
+
+func (r *reader) jumpTo(rowIndex int) error {
+	for r.r.LineNum() < rowIndex {
+		_, err := r.r.Read()
+		if err == io.EOF {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *reader) recordToNode(record []string) *idr.Node {
+	root := idr.CreateNode(idr.ElementNode, "")
+	// - If actual record has more columns than declared in schema, we'll only use up to
+	//   what's declared in the schema;
+	// - conversely, if the actual record has less columns than declared in schema, we'll
+	//   use all that are in the record.
+	for i := 0; i < maths.MinInt(len(record), len(r.decl.Columns)); i++ {
+		col := idr.CreateNode(idr.ElementNode, r.decl.Columns[i].name())
+		idr.AddChild(root, col)
+		data := idr.CreateNode(idr.TextNode, record[i])
+		idr.AddChild(col, data)
+	}
+	return root
+}
+
+func (r *reader) IsContinuableError(err error) bool {
+	return !IsErrInvalidHeader(err) && err != io.EOF
+}
+
+func (r *reader) FmtErr(format string, args ...interface{}) error {
+	return errors.New(r.fmtErrStr(format, args...))
+}
+
+func (r *reader) fmtErrStr(format string, args ...interface{}) string {
+	return fmt.Sprintf("input '%s' line %d: %s", r.inputName, r.r.LineNum(), fmt.Sprintf(format, args...))
+}
+
+// NewReader creates an FormatReader for CSV file format for omniv2 schema handler.
+func NewReader(inputName string, r io.Reader, decl *fileDecl, xpathStr string) (*reader, error) {
+	var expr *xpath.Expr
+	var err error
+	xpathStr = strings.TrimSpace(xpathStr)
+	if xpathStr != "" && xpathStr != "." {
+		expr, err = caches.GetXPathExpr(xpathStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid xpath '%s', err: %s", xpathStr, err.Error())
+		}
+	}
+	if decl.ReplaceDoubleQuotes {
+		r = ios.NewBytesReplacingReader(r, []byte(`"`), []byte(`'`))
+	}
+	csv := ios.NewLineNumReportingCsvReader(r)
+	delim := []rune(decl.Delimiter)
+	csv.Comma = delim[0]
+	csv.FieldsPerRecord = -1
+	csv.ReuseRecord = true
+	return &reader{
+		inputName:     inputName,
+		decl:          decl,
+		r:             csv,
+		headerChecked: false,
+		xpath:         expr,
+	}, nil
+}

--- a/handlers/omni/v2/fileformat/csv/reader_test.go
+++ b/handlers/omni/v2/fileformat/csv/reader_test.go
@@ -1,0 +1,179 @@
+package omniv2csv
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/jf-tech/go-corelib/jsons"
+	"github.com/jf-tech/go-corelib/strs"
+	"github.com/jf-tech/go-corelib/testlib"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/idr"
+)
+
+func TestIsErrInvalidHeader(t *testing.T) {
+	assert.True(t, IsErrInvalidHeader(ErrInvalidHeader("test")))
+	assert.Equal(t, "test", ErrInvalidHeader("test").Error())
+	assert.False(t, IsErrInvalidHeader(errors.New("test")))
+}
+
+func TestNewReader_InvalidXPath(t *testing.T) {
+	r, err := NewReader("test", nil, nil, "[invalid")
+	assert.Error(t, err)
+	assert.Equal(t, `invalid xpath '[invalid', err: expression must evaluate to a node-set`, err.Error())
+	assert.Nil(t, r)
+}
+
+func lf(s string) string {
+	return s + "\n"
+}
+
+func TestReader(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		decl     *fileDecl
+		xpath    string
+		input    io.Reader
+		expected []interface{}
+	}{
+		{
+			name: "header row; alias used; with xpath; variable data row column size; replace double quote",
+			decl: &fileDecl{
+				Delimiter:           "|",
+				ReplaceDoubleQuotes: true,
+				HeaderRowIndex:      testlib.IntPtr(2),
+				DataRowIndex:        4,
+				Columns: []column{
+					{Name: "a"},
+					{Name: "b with space", Alias: strs.StrPtr("b_with_space")},
+					{Name: "c"},
+				},
+			},
+			xpath: ".[a != 'skip']",
+			input: strings.NewReader(lf("line1") +
+				lf("a|b with space|c") +
+				lf("line3") +
+				lf(`1|"2|3`) + // put an unescaped double quote here to see if our replacement works or not.
+				lf("") + // auto skipped by csv reader.
+				lf("skip") + // skipped by the xpath.
+				lf("one|two")),
+			expected: []interface{}{
+				`{ "a": "1", "b_with_space": "'2", "c": "3" }`,
+				`{ "a": "one", "b_with_space": "two" }`,
+			},
+		},
+		{
+			name: "cannot jump to header row",
+			decl: &fileDecl{
+				Delimiter:      "|",
+				HeaderRowIndex: testlib.IntPtr(3),
+			},
+			input: strings.NewReader(lf("line1")),
+			expected: []interface{}{
+				ErrInvalidHeader("input 'test-input' line 2: unable to read header: EOF"),
+			},
+		},
+		{
+			name: "cannot read to header row",
+			decl: &fileDecl{
+				Delimiter:      "|",
+				HeaderRowIndex: testlib.IntPtr(2),
+			},
+			input: strings.NewReader(lf("line1")),
+			expected: []interface{}{
+				ErrInvalidHeader("input 'test-input' line 2: unable to read header: EOF"),
+			},
+		},
+		{
+			name: "header columns less than the declared",
+			decl: &fileDecl{
+				Delimiter:      "|",
+				HeaderRowIndex: testlib.IntPtr(2),
+				Columns: []column{
+					{Name: "a"},
+					{Name: "b"},
+				},
+			},
+			input: strings.NewReader(lf("line1") + lf("a")),
+			expected: []interface{}{
+				ErrInvalidHeader("input 'test-input' line 2: actual header column size (1) is less than the size (2) declared in file_declaration.columns in schema"),
+			},
+		},
+		{
+			name: "header column not matching the declared",
+			decl: &fileDecl{
+				Delimiter:      "|",
+				HeaderRowIndex: testlib.IntPtr(2),
+				Columns: []column{
+					{Name: "a"},
+					{Name: "b"},
+				},
+			},
+			input: strings.NewReader(lf("line1") + lf("a|B")),
+			expected: []interface{}{
+				ErrInvalidHeader("input 'test-input' line 2: header column[2] 'B' does not match declared column name 'b' in schema"),
+			},
+		},
+		{
+			name: "header row but no data row",
+			decl: &fileDecl{
+				Delimiter:      ",",
+				HeaderRowIndex: testlib.IntPtr(2),
+				DataRowIndex:   4,
+				Columns: []column{
+					{Name: "a"},
+					{Name: "b"},
+				},
+			},
+			input:    strings.NewReader(lf("line1") + lf("a,b") + lf("line3")),
+			expected: nil,
+		},
+		{
+			name: "unable to read data row",
+			decl: &fileDecl{
+				Delimiter:    ",",
+				DataRowIndex: 1,
+				Columns:      []column{{Name: "a"}},
+			},
+			input: testlib.NewMockReadCloser("read failure", nil),
+			expected: []interface{}{
+				errors.New("input 'test-input' line 1: failed to fetch record: read failure"),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r, err := NewReader("test-input", test.input, test.decl, test.xpath)
+			assert.NoError(t, err)
+			for {
+				n, err := r.Read()
+				if err == io.EOF {
+					assert.Equal(t, 0, len(test.expected))
+					assert.Nil(t, n)
+					break
+				}
+				assert.True(t, len(test.expected) > 0)
+				if expectedErr, ok := test.expected[0].(error); ok {
+					assert.Error(t, err)
+					assert.Equal(t, expectedErr, err)
+					assert.Nil(t, n)
+					assert.Equal(t, 1, len(test.expected)) // if there is an error, it will be the last one.
+					break
+				}
+				expectedJSON, ok := test.expected[0].(string)
+				assert.True(t, ok)
+				assert.Equal(t, jsons.BPJ(expectedJSON), jsons.BPJ(idr.JSONify2(n)))
+				test.expected = test.expected[1:]
+			}
+		})
+	}
+}
+
+func TestIsContinuableError(t *testing.T) {
+	r := &reader{}
+	assert.True(t, r.IsContinuableError(errors.New("some error")))
+	assert.False(t, r.IsContinuableError(ErrInvalidHeader("invalid header")))
+	assert.False(t, r.IsContinuableError(io.EOF))
+}

--- a/handlers/omni/v2/fileformat/csv/reader_test.go
+++ b/handlers/omni/v2/fileformat/csv/reader_test.go
@@ -122,7 +122,7 @@ func TestReader(t *testing.T) {
 			decl: &fileDecl{
 				Delimiter:      ",",
 				HeaderRowIndex: testlib.IntPtr(2),
-				DataRowIndex:   4,
+				DataRowIndex:   5,
 				Columns: []column{
 					{Name: "a"},
 					{Name: "b"},

--- a/handlers/omni/v2/fileformat/fileformat.go
+++ b/handlers/omni/v2/fileformat/fileformat.go
@@ -26,7 +26,7 @@ type FileFormat interface {
 // stream content before doing the xpath/node based parsing.
 type FormatReader interface {
 	// Read returns a *Node and its subtree that will eventually be parsed and transformed into an
-	// output record.
+	// output record. If EOF has been reached, io.EOF must be returned.
 	Read() (*idr.Node, error)
 	// IsContinuableError determines whether an FormatReader returned error is continuable or not.
 	// For certain errors (like EOF or corruption) there is no point to keep on trying; while others

--- a/handlers/omni/v2/fileformat/json/format_test.go
+++ b/handlers/omni/v2/fileformat/json/format_test.go
@@ -1,6 +1,7 @@
 package omniv2json
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -91,7 +92,7 @@ func TestCreateFormatReader(t *testing.T) {
 	t.Run("EOF", func(t *testing.T) {
 		n3, err := r.Read()
 		assert.Error(t, err)
-		assert.Equal(t, errs.ErrEOF, err)
+		assert.Equal(t, io.EOF, err)
 		assert.Nil(t, n3)
 	})
 

--- a/handlers/omni/v2/fileformat/json/reader.go
+++ b/handlers/omni/v2/fileformat/json/reader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/jf-tech/omniparser/errs"
 	"github.com/jf-tech/omniparser/idr"
 )
 
@@ -33,7 +32,7 @@ type reader struct {
 func (r *reader) Read() (*idr.Node, error) {
 	n, err := r.r.Read()
 	if err == io.EOF {
-		return nil, errs.ErrEOF
+		return nil, io.EOF
 	}
 	if err != nil {
 		return nil, ErrNodeReadingFailed(r.fmtErrStr(err.Error()))
@@ -42,7 +41,7 @@ func (r *reader) Read() (*idr.Node, error) {
 }
 
 func (r *reader) IsContinuableError(err error) bool {
-	return !IsErrNodeReadingFailed(err) && err != errs.ErrEOF
+	return !IsErrNodeReadingFailed(err) && err != io.EOF
 }
 
 func (r *reader) FmtErr(format string, args ...interface{}) error {
@@ -53,7 +52,7 @@ func (r *reader) fmtErrStr(format string, args ...interface{}) string {
 	return fmt.Sprintf("input '%s' before/near line %d: %s", r.inputName, r.r.AtLine(), fmt.Sprintf(format, args...))
 }
 
-// NewReader creates an InputReader for JSON file format for omniv2 schema handler.
+// NewReader creates an FormatReader for JSON file format for omniv2 schema handler.
 func NewReader(inputName string, src io.Reader, xpath string) (*reader, error) {
 	sp, err := idr.NewJSONStreamReader(src, xpath)
 	if err != nil {

--- a/handlers/omni/v2/fileformat/json/reader_test.go
+++ b/handlers/omni/v2/fileformat/json/reader_test.go
@@ -2,6 +2,7 @@ package omniv2json
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -55,7 +56,7 @@ func TestReader_Read_Success(t *testing.T) {
 
 	n, err = r.Read()
 	assert.Error(t, err)
-	assert.Equal(t, errs.ErrEOF, err)
+	assert.Equal(t, io.EOF, err)
 	assert.Nil(t, n)
 }
 
@@ -83,7 +84,7 @@ func TestReader_FmtErr(t *testing.T) {
 func TestReader_IsContinuableError(t *testing.T) {
 	r, err := NewReader("test", strings.NewReader(""), "/A/B")
 	assert.NoError(t, err)
-	assert.False(t, r.IsContinuableError(errs.ErrEOF))
+	assert.False(t, r.IsContinuableError(io.EOF))
 	assert.False(t, r.IsContinuableError(ErrNodeReadingFailed("failure")))
 	assert.True(t, r.IsContinuableError(errs.ErrTransformFailed("failure")))
 	assert.True(t, r.IsContinuableError(errors.New("failure")))

--- a/handlers/omni/v2/fileformat/xml/format_test.go
+++ b/handlers/omni/v2/fileformat/xml/format_test.go
@@ -1,6 +1,7 @@
 package omniv2xml
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -91,7 +92,7 @@ func TestCreateFormatReader(t *testing.T) {
 	t.Run("EOF", func(t *testing.T) {
 		n3, err := r.Read()
 		assert.Error(t, err)
-		assert.Equal(t, errs.ErrEOF, err)
+		assert.Equal(t, io.EOF, err)
 		assert.Nil(t, n3)
 	})
 

--- a/handlers/omni/v2/fileformat/xml/reader.go
+++ b/handlers/omni/v2/fileformat/xml/reader.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/jf-tech/omniparser/errs"
 	"github.com/jf-tech/omniparser/idr"
 )
 
@@ -33,7 +32,7 @@ type reader struct {
 func (r *reader) Read() (*idr.Node, error) {
 	n, err := r.r.Read()
 	if err == io.EOF {
-		return nil, errs.ErrEOF
+		return nil, io.EOF
 	}
 	if err != nil {
 		return nil, ErrNodeReadingFailed(r.fmtErrStr(err.Error()))
@@ -42,7 +41,7 @@ func (r *reader) Read() (*idr.Node, error) {
 }
 
 func (r *reader) IsContinuableError(err error) bool {
-	return !IsErrNodeReadingFailed(err) && err != errs.ErrEOF
+	return !IsErrNodeReadingFailed(err) && err != io.EOF
 }
 
 func (r *reader) FmtErr(format string, args ...interface{}) error {
@@ -53,7 +52,7 @@ func (r *reader) fmtErrStr(format string, args ...interface{}) string {
 	return fmt.Sprintf("input '%s' near line %d: %s", r.inputName, r.r.AtLine(), fmt.Sprintf(format, args...))
 }
 
-// NewReader creates an InputReader for XML file format for omniv2 schema handler.
+// NewReader creates an FormatReader for XML file format for omniv2 schema handler.
 func NewReader(inputName string, src io.Reader, xpath string) (*reader, error) {
 	sp, err := idr.NewXMLStreamReader(src, xpath)
 	if err != nil {

--- a/handlers/omni/v2/fileformat/xml/reader_test.go
+++ b/handlers/omni/v2/fileformat/xml/reader_test.go
@@ -2,6 +2,7 @@ package omniv2xml
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestReader_Read_Success(t *testing.T) {
 
 	n, err = r.Read()
 	assert.Error(t, err)
-	assert.Equal(t, errs.ErrEOF, err)
+	assert.Equal(t, io.EOF, err)
 	assert.Nil(t, n)
 }
 
@@ -72,7 +73,7 @@ func TestReader_FmtErr(t *testing.T) {
 func TestReader_IsContinuableError(t *testing.T) {
 	r, err := NewReader("test", strings.NewReader(""), "Root/Node")
 	assert.NoError(t, err)
-	assert.False(t, r.IsContinuableError(errs.ErrEOF))
+	assert.False(t, r.IsContinuableError(io.EOF))
 	assert.False(t, r.IsContinuableError(ErrNodeReadingFailed("failure")))
 	assert.True(t, r.IsContinuableError(errs.ErrTransformFailed("failure")))
 	assert.True(t, r.IsContinuableError(errors.New("failure")))

--- a/handlers/omni/v2/ingester_test.go
+++ b/handlers/omni/v2/ingester_test.go
@@ -3,6 +3,7 @@ package omniv2
 import (
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ type testReader struct {
 
 func (r *testReader) Read() (*idr.Node, error) {
 	if len(r.result) == 0 {
-		return nil, errs.ErrEOF
+		return nil, io.EOF
 	}
 	result := r.result[0]
 	err := r.err[0]

--- a/samples/omniv2/customfileformats/jsonlog/jsonlogformat/reader.go
+++ b/samples/omniv2/customfileformats/jsonlog/jsonlogformat/reader.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jf-tech/go-corelib/ios"
 	"github.com/jf-tech/go-corelib/strs"
 
-	"github.com/jf-tech/omniparser/errs"
 	"github.com/jf-tech/omniparser/idr"
 )
 
@@ -44,7 +43,7 @@ func (r *reader) Read() (*idr.Node, error) {
 		r.line++
 		l, err := ios.ReadLine(r.r)
 		if err == io.EOF {
-			return nil, errs.ErrEOF
+			return nil, io.EOF
 		}
 		if err != nil {
 			// If we fail to read a log line out (permission issue, disk issue, whatever)
@@ -80,7 +79,7 @@ func parseJSON(b []byte) (*idr.Node, error) {
 }
 
 func (r *reader) IsContinuableError(err error) bool {
-	return !IsErrLogReadingFailed(err) && err != errs.ErrEOF
+	return !IsErrLogReadingFailed(err) && err != io.EOF
 }
 
 func (r *reader) FmtErr(format string, args ...interface{}) error {
@@ -91,7 +90,7 @@ func (r *reader) fmtErrStr(format string, args ...interface{}) string {
 	return fmt.Sprintf("input '%s' line %d: %s", r.inputName, r.line, fmt.Sprintf(format, args...))
 }
 
-// NewReader creates an InputReader for this sample jsonlog file format.
+// NewReader creates an FormatReader for this sample jsonlog file format.
 func NewReader(inputName string, src io.Reader, filterXPath string) (*reader, error) {
 	filter, err := caches.GetXPathExpr(filterXPath)
 	if err != nil {

--- a/transform.go
+++ b/transform.go
@@ -1,6 +1,8 @@
 package omniparser
 
 import (
+	"io"
+
 	"github.com/jf-tech/omniparser/errs"
 	"github.com/jf-tech/omniparser/handlers"
 )
@@ -39,7 +41,7 @@ func (o *transform) Next() bool {
 			o.curRecord = record
 			o.curErr = nil
 			return true
-		case err == errs.ErrEOF:
+		case err == io.EOF:
 			o.curErr = err
 			o.curRecord = nil
 			// No more processing needed.

--- a/transform_test.go
+++ b/transform_test.go
@@ -3,6 +3,7 @@ package omniparser
 import (
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +48,7 @@ func TestTransform_EndWithEOF(t *testing.T) {
 				{record: []byte("1st good read")},
 				{err: continuableErr1},
 				{record: []byte("2nd good read")},
-				{err: errs.ErrEOF},
+				{err: io.EOF},
 			},
 			continuableErrs: map[error]bool{continuableErr1: true},
 		},
@@ -72,14 +73,14 @@ func TestTransform_EndWithEOF(t *testing.T) {
 	assert.False(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.Error(t, err)
-	assert.Equal(t, errs.ErrEOF, err)
+	assert.Equal(t, io.EOF, err)
 	assert.Nil(t, record)
 
 	// Verifying when EOF is reached, repeatedly calling Next will still get you EOF.
 	assert.False(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.Error(t, err)
-	assert.Equal(t, errs.ErrEOF, err)
+	assert.Equal(t, io.EOF, err)
 	assert.Nil(t, record)
 }
 


### PR DESCRIPTION
The key diff/improvement is now we add xpath to the csv reader so that we can perform both positive row selection as well as negative row skipping. Much more powerful than the old row skipping thingy.

Next PR will bring the FileFormat implementation in, which will complete the csv fileformat.