### PR TITLE
Add EDI's `file_declaration` struct definition and implement `ediReader.getUnprocessedRawSeg`

### DIFF
--- a/extensions/omniv21/fileformat/edi/bench_test.go
+++ b/extensions/omniv21/fileformat/edi/bench_test.go
@@ -371,7 +371,7 @@ var (
 	}()
 )
 
-// BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar-8   	    8971	    114907 ns/op	   48024 B/op	     747 allocs/op
+// BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar-8   	   10000	    103945 ns/op	   27080 B/op	     515 allocs/op
 func BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		reader := NewReader("test", strings.NewReader(benchInputNoCompNoReleaseChar), benchDeclNoCompNoReleaseChar)
@@ -505,7 +505,7 @@ var (
 	}()
 )
 
-// BenchmarkGetUnprocessedRawSeg_WithCompAndRelease-8    	    7077	    168176 ns/op	  227497 B/op	     816 allocs/op
+// BenchmarkGetUnprocessedRawSeg_WithCompAndRelease-8    	   14174	     84115 ns/op	  102880 B/op	     385 allocs/op
 func BenchmarkGetUnprocessedRawSeg_WithCompAndRelease(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		reader := NewReader("test", strings.NewReader(benchInputWithCompAndRelease), benchDeclWithCompAndRelease)

--- a/extensions/omniv21/fileformat/edi/bench_test.go
+++ b/extensions/omniv21/fileformat/edi/bench_test.go
@@ -1,0 +1,389 @@
+package edi
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+// Adding a benchmark for rawSeg operation to ensure there is no alloc:
+// BenchmarkRawSeg-8   	81410766	        13.9 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkRawSeg(b *testing.B) {
+	rawSegName := "test"
+	rawSegData := []byte("test data")
+	r := ediReader{
+		unprocessedRawSeg: newRawSeg(),
+	}
+	for i := 0; i < b.N; i++ {
+		r.resetRawSeg()
+		r.unprocessedRawSeg.valid = true
+		r.unprocessedRawSeg.name = rawSegName
+		r.unprocessedRawSeg.raw = rawSegData
+		r.unprocessedRawSeg.elems = append(
+			r.unprocessedRawSeg.elems, rawSegElem{1, 1, rawSegData[0:4]}, rawSegElem{2, 1, rawSegData[5:]})
+	}
+}
+
+// Adding a benchmark for stack operation to ensure there is no alloc:
+// BenchmarkGrownShrinkStack-8    	12901227	        89.0 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkGrownShrinkStack(b *testing.B) {
+	r := ediReader{
+		stack: newStack(),
+	}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 20; j++ {
+			r.growStack(stackEntry{})
+		}
+		for r.shrinkStack() != nil {
+		}
+	}
+}
+
+const (
+	benchInputNoCompNoReleaseChar = `
+ISA*00*          *00*          *02*CPC            *ZZ*00602679321    *191103*1800*U*00401*000001644*0*P*>
+GS*QM*CPC*00602679321*20191103*1800*000001644*X*004010
+ST*214*000000001
+B10*4343638097845589              *4343638097845589              *CPCC
+L11*4343638097845589*97
+L11*0000*86
+N1*SF*00602679321
+N1*ST*The Rock
+N3*264040 DONUT-TOWN 473*
+N4*HAMMER*AB*T0C1Z0*CA
+LX*000001
+AT7*XB*NS***20191103*1534*
+MS1*WRENCH*ON*CA
+AT8*G*K*4
+SE*0000000013*000000001
+ST*214*000000002
+B10*4343638098050296              *4343638098050296              *CPCC
+L11*4343638098050296*97
+L11*0156*86
+N1*SF*00602679321
+N1*ST*The Terminator
+N3*PO BOX 12345 RPO 21ST AVE*MARKET
+N4*DRILL*BC*V5L0B3*CA
+LX*000001
+AT7*AH*AG***20191102*1625*PT
+MS1*DRILL*BC*CA
+AT8*G*K*0
+SE*0000000013*000000002
+ST*214*000000003
+B10*4343638931638575              *4343638931638575              *CPCC
+L11*3001100072*97
+L11*1303*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 42*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*CA*BT***20191102*1752*PT
+MS1*SAW*BC*CA
+AT8*G*K*0
+SE*0000000013*000000003
+ST*214*000000004
+B10*4343638098146166              *4343638098146166              *CPCC
+L11*4343638098146166*97
+L11*1498*86
+N1*SF*00602679321
+N1*ST*The Joker
+N3*RR 1*
+N4*SWITCH*AB*T0C0J0*CA
+LX*000001
+AT7*D1*NS***20191102*1648*MT
+MS1*SWITCH*AB*CA
+L11**CI
+AT8*G*K*15
+SE*0000000014*000000004
+ST*214*000000005
+B10*4343638098181877              *4343638098181877              *CPCC
+L11*4343638098181877*97
+L11*0410*86
+N1*SF*00602679321
+N1*ST*The Autobot
+N3*PO BOX 314*159 26 ST-GRINDER
+N4*SCREWDRIVER*SK*S0M0E0*CA
+LX*000001
+AT7*AF*NS***20191103*1509*CS
+MS1*PAINTBRUSH*MB*CA
+AT8*G*K*1
+SE*0000000013*000000005
+ST*214*000000006
+B10*4343638098181891              *4343638098181891              *CPCC
+L11*4343638098181891*97
+L11*0410*86
+N1*SF*00602679321
+N1*ST*The Hobbit
+N3*PO BOX 42*
+N4*MITERSAW*SK*S0M1C0*CA
+LX*000001
+AT7*AF*NS***20191103*1509*CS
+MS1*PAINTBRUSH*MB*CA
+AT8*G*K*19
+SE*0000000013*000000006
+ST*214*000000007
+B10*4343638098181921              *4343638098181921              *CPCC
+L11*4343638098181921*97
+L11*0100*86
+N1*SF*00602679321
+N1*ST*The Avengers
+N3*PO BOX 135*HOUSE 9 IMPACTDRILL
+N4*WETVAC*MB*R0A1E0*CA
+LX*000001
+AT7*XB*NS***20191103*1131*CS
+MS1*PAINTBRUSH*MB*CA
+AT8*G*K*0
+SE*0000000013*000000007
+ST*214*000000008
+B10*4343638098186995              *4343638098186995              *CPCC
+L11*4343638098186995*97
+L11*0410*86
+N1*SF*00602679321
+N1*ST*The Hulk
+N3*PO BOX 000*
+N4*PRESSUREWASHER*SK*S0K2L0*CA
+LX*000001
+AT7*AF*NS***20191103*1509*CS
+MS1*PAINTBRUSH*MB*CA
+AT8*G*K*0
+SE*0000000013*000000008
+ST*214*000000009
+B10*4343638151403540              *4343638151403540              *CPCC
+L11*5653512*97
+L11*0175*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 1122*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*AF*NS***20191103*1125*MT
+MS1*LASERLEVEL*AB*CA
+AT8*G*K*0
+SE*0000000013*000000009
+ST*214*000000010
+B10*4343638151403540              *4343638151403540              *CPCC
+L11*5653512*97
+L11*0100*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 1122*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*XB*NS***20191103*0853*MT
+MS1*LASERLEVEL*AB*CA
+AT8*G*K*0
+SE*0000000013*000000010
+ST*214*000000011
+B10*4343638316026577              *4343638316026577              *CPCC
+L11*300521101*97
+L11*0410*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 1122*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*AF*NS***20191103*0837*MT
+MS1*LASERLEVEL*AB*CA
+AT8*G*K*0
+SE*0000000013*000000011
+ST*214*000000012
+B10*4343638316026577              *4343638316026577              *CPCC
+L11*300521101*97
+L11*0405*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 1122*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*AP*AG***20191103*0815*MT
+MS1*LASERLEVEL*AB*CA
+AT8*G*K*0
+SE*0000000013*000000012
+ST*214*000000013
+B10*4343638316026577              *4343638316026577              *CPCC
+L11*300521101*97
+L11*0410*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 1122*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*AF*NS***20191102*1555*PT
+MS1*NAILGUN*BC*CA
+AT8*G*K*0
+SE*0000000013*000000013
+ST*214*000000014
+B10*4343638672340607              *4343638672340607              *CPCC
+L11*300633104*97
+L11*0405*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 1122*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*AP*AG***20191103*0733*CS
+MS1*PAINTBRUSH*MB*CA
+AT8*G*K*0
+SE*0000000013*000000014
+ST*214*000000015
+B10*4343638098171441              *4343638098171441              *CPCC
+L11*4343638098171441*97
+L11*0100*86
+N1*SF*00602679321
+N1*ST*The Dragon Ball
+N3*PO BOX 314*159 2 ST
+N4*WOODGLUE*AB*T0K2E0*CA
+LX*000001
+AT7*XB*NS***20191103*0904*MT
+MS1*LASERLEVEL*AB*CA
+AT8*G*K*16
+SE*0000000013*000000015
+ST*214*000000016
+B10*4343638098171472              *4343638098171472              *CPCC
+L11*4343638098171472*97
+L11*0410*86
+N1*SF*00602679321
+N1*ST*The X-men
+N3*PO BOX 314*1592 WIREBOX PL
+N4*DRYWALL*SK*S0L0P0*CA
+LX*000001
+AT7*AF*NS***20191103*1509*CS
+MS1*PAINTBRUSH*MB*CA
+AT8*G*K*3
+SE*0000000013*000000016
+ST*214*000000017
+B10*4343638098176088              *4343638098176088              *CPCC
+L11*4343638098176088*97
+L11*0405*86
+N1*SF*00602679321
+N1*ST*The Matrix
+N3*PO BOX 314*159 UP ST
+N4*FUSE*SK*S0C1S0*CA
+LX*000001
+AT7*AP*AG***20191103*0631*CS
+MS1*SHEETROCK*SK*CA
+AT8*G*K*0
+SE*0000000013*000000017
+ST*214*000000018
+B10*4343638458862606              *4343638458862606              *CPCC
+L11*3001570460*97
+L11*0104*86
+N1*SF*00602679321
+N1*ST*
+N3*PO BOX 1122*
+N4*WRENCH*ON*N5Y5W3*CA
+LX*000001
+AT7*XB*NS***20191103*1728*ET
+MS1*PVCPIPE*ON*CA
+AT8*G*K*0
+SE*0000000013*000000018
+ST*214*000000019
+B10*4343638098196574              *4343638098196574              *CPCC
+L11*4343638098196574*97
+L11*0104*86
+N1*SF*00602679321
+N1*ST*The Beast
+N3*PO BOX 314*1592 HWY 551
+N4*WIRECUTTER*ON*P0P1S0*CA
+LX*000001
+AT7*XB*NS***20191103*1618*ET
+MS1*TORCH*ON*CA
+AT8*G*K*1
+SE*0000000013*000000019
+GE*000019*000001644
+IEA*00001*000001644
+`
+
+	benchDeclNoCompNoReleaseCharJSON = `
+{
+        "segment_delimiter": "\n",
+        "element_delimiter": "*",
+        "segment_declarations": [
+            {
+                "name": "ISA",
+                "child_segments": [
+                    {
+                        "name": "GS",
+                        "child_segments": [
+                            {
+                                "name": "scanInfo", "type": "segment_group", "min": 0, "max": -1, "is_target": true,
+                                "child_segments": [
+                                    { "name": "ST" },
+                                    { "name": "B10", "elements": [ { "name": "shipmentIdentificationNumber", "index": 2 } ] },
+                                    { "name": "L11" },
+                                    { "name": "L11" },
+                                    { "name": "N1" },
+                                    { "name": "N1" },
+                                    { "name": "N3" },
+                                    {
+                                        "name": "N4",
+                                        "elements": [
+                                            { "name": "cityName", "index": 1 },
+                                            { "name": "provinceCode", "index": 2 },
+                                            { "name": "postalCode", "index": 3 },
+                                            { "name": "countryCode", "index": 4 }
+                                        ]
+                                    },
+                                    { "name": "LX" },
+                                    {
+                                        "name": "AT7",
+                                        "elements": [
+                                            { "name": "shipmentStatusCode", "index": 1 },
+                                            { "name": "shipmentStatusReasonCode", "index": 2 },
+                                            { "name": "date", "index": 5 },
+                                            { "name": "time", "index": 6 },
+                                            { "name": "timeCode", "index": 7 }
+                                        ]
+                                    },
+                                    {
+                                        "name": "MS1",
+                                        "elements": [
+                                            { "name": "cityName", "index": 1 },
+                                            { "name": "provinceCode", "index": 2 },
+                                            { "name": "countryCode", "index": 3 }
+                                        ]
+                                    },
+                                    { "name": "L11", "min": 0 },
+                                    { "name": "AT8" },
+                                    { "name": "SE" }
+                                ]
+                            }
+                        ]
+                    },
+                    { "name": "GE" }
+                ]
+            },
+            { "name": "IEA" }
+        ]
+    }`
+)
+
+var (
+	benchDeclNoCompNoReleaseChar = func() *fileDecl {
+		var fd fileDecl
+		err := json.Unmarshal([]byte(benchDeclNoCompNoReleaseCharJSON), &fd)
+		if err != nil {
+			panic(err)
+		}
+		return &fd
+	}()
+)
+
+// BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar-8   	    8971	    114907 ns/op	   48024 B/op	     747 allocs/op
+func BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		reader := NewReader("test", strings.NewReader(benchInputNoCompNoReleaseChar), benchDeclNoCompNoReleaseChar)
+		for {
+			_, err := reader.getUnprocessedRawSeg()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.FailNow()
+			}
+			reader.resetRawSeg()
+		}
+	}
+}

--- a/extensions/omniv21/fileformat/edi/bench_test.go
+++ b/extensions/omniv21/fileformat/edi/bench_test.go
@@ -298,66 +298,66 @@ IEA*00001*000001644
 
 	benchDeclNoCompNoReleaseCharJSON = `
 {
-        "segment_delimiter": "\n",
-        "element_delimiter": "*",
-        "segment_declarations": [
-            {
-                "name": "ISA",
-                "child_segments": [
-                    {
-                        "name": "GS",
-                        "child_segments": [
-                            {
-                                "name": "scanInfo", "type": "segment_group", "min": 0, "max": -1, "is_target": true,
-                                "child_segments": [
-                                    { "name": "ST" },
-                                    { "name": "B10", "elements": [ { "name": "shipmentIdentificationNumber", "index": 2 } ] },
-                                    { "name": "L11" },
-                                    { "name": "L11" },
-                                    { "name": "N1" },
-                                    { "name": "N1" },
-                                    { "name": "N3" },
-                                    {
-                                        "name": "N4",
-                                        "elements": [
-                                            { "name": "cityName", "index": 1 },
-                                            { "name": "provinceCode", "index": 2 },
-                                            { "name": "postalCode", "index": 3 },
-                                            { "name": "countryCode", "index": 4 }
-                                        ]
-                                    },
-                                    { "name": "LX" },
-                                    {
-                                        "name": "AT7",
-                                        "elements": [
-                                            { "name": "shipmentStatusCode", "index": 1 },
-                                            { "name": "shipmentStatusReasonCode", "index": 2 },
-                                            { "name": "date", "index": 5 },
-                                            { "name": "time", "index": 6 },
-                                            { "name": "timeCode", "index": 7 }
-                                        ]
-                                    },
-                                    {
-                                        "name": "MS1",
-                                        "elements": [
-                                            { "name": "cityName", "index": 1 },
-                                            { "name": "provinceCode", "index": 2 },
-                                            { "name": "countryCode", "index": 3 }
-                                        ]
-                                    },
-                                    { "name": "L11", "min": 0 },
-                                    { "name": "AT8" },
-                                    { "name": "SE" }
-                                ]
-                            }
-                        ]
-                    },
-                    { "name": "GE" }
-                ]
-            },
-            { "name": "IEA" }
-        ]
-    }`
+	"segment_delimiter": "\n",
+	"element_delimiter": "*",
+	"segment_declarations": [
+		{
+			"name": "ISA",
+			"child_segments": [
+				{
+					"name": "GS",
+					"child_segments": [
+						{
+							"name": "scanInfo", "type": "segment_group", "min": 0, "max": -1, "is_target": true,
+							"child_segments": [
+								{ "name": "ST" },
+								{ "name": "B10", "elements": [ { "name": "shipment_id", "index": 2 } ] },
+								{ "name": "L11" },
+								{ "name": "L11" },
+								{ "name": "N1" },
+								{ "name": "N1" },
+								{ "name": "N3" },
+								{
+									"name": "N4",
+									"elements": [
+										{ "name": "city", "index": 1 },
+										{ "name": "province", "index": 2 },
+										{ "name": "zip", "index": 3 },
+										{ "name": "country", "index": 4 }
+									]
+								},
+								{ "name": "LX" },
+								{
+									"name": "AT7",
+									"elements": [
+										{ "name": "status_code", "index": 1 },
+										{ "name": "reason_code", "index": 2 },
+										{ "name": "date", "index": 5 },
+										{ "name": "time", "index": 6 },
+										{ "name": "time_code", "index": 7 }
+									]
+								},
+								{
+									"name": "MS1",
+									"elements": [
+										{ "name": "city", "index": 1 },
+										{ "name": "province", "index": 2 },
+										{ "name": "country", "index": 3 }
+									]
+								},
+								{ "name": "L11", "min": 0 },
+								{ "name": "AT8" },
+								{ "name": "SE" }
+							]
+						}
+					]
+				},
+				{ "name": "GE" }
+			]
+		},
+		{ "name": "IEA" }
+	]
+}`
 )
 
 var (
@@ -375,6 +375,140 @@ var (
 func BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		reader := NewReader("test", strings.NewReader(benchInputNoCompNoReleaseChar), benchDeclNoCompNoReleaseChar)
+		for {
+			_, err := reader.getUnprocessedRawSeg()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.FailNow()
+			}
+			reader.resetRawSeg()
+		}
+	}
+}
+
+const (
+	benchInputWithCompAndRelease    = `UNA:+.? 'UNB+UNOC:3+7080000714520:14+BPGARMIN:ZZZ+202502:1715+20202502171538'UNH+1+IFTSTA:D:04A:UN:BIG07'BGM+77+70726206369762052+9'DTM+137:202025021715:203'NAD+CZ+20000181402::87'CNI+1+70726206369762052'STS+1+S::87:REFORWARDED'RFF+CU:171577008'DTM+78:202002251728:203'LOC+14+01530:16::VANTAA+FI:162'GID+1+1'PCI+30+370726206369762060'STS+1+V::87:ERROR OCCURED IN PROCESSING+99::87:Other / unknown reason+Z::87:Other / unknown reason'RFF+CU:171577008'DTM+78:202002251729:203'LOC+14+01530:16::VANTAA+FI:162'GID+1+1'PCI+30+370726206369762060'STS+1+S::87:REFORWARDED'RFF+CU:171577008'DTM+78:202002251732:203'LOC+14+01530:16::VANTAA+FI:162'GID+1+1'PCI+30+370726206369762060'UNT+24+1'UNH+2+IFTSTA:D:04A:UN:BIG07'BGM+77+70726206369728447+9'DTM+137:202025021715:203'NAD+CZ+20000181410::87'CNI+1+70726206369728447'STS+1+I::87:DELIVERED'RFF+CU:171452065'DTM+78:202002251709:203'LOC+14+0701:16::OSLO+NO:162'GID+1+1'PCI+30+370726206369728455'UNT+12+2'UNH+3+IFTSTA:D:04A:UN:BIG07'BGM+77+70726206369754293+9'DTM+137:202025021715:203'NAD+CZ+20000181410::87'CNI+1+70726206369754293'STS+1+I::87:DELIVERED'RFF+CU:171559197'DTM+78:202002251704:203'LOC+14+6101:16::VOLDA+NO:162'GID+1+1'PCI+30+370726206369754300'UNT+12+3'UNH+4+IFTSTA:D:04A:UN:BIG07'BGM+77+70726206369762663+9'DTM+137:202025021715:203'NAD+CZ+20000181410::87'CNI+1+70726206369762663'STS+1+Q::87:ARRIVED AT POST OFFICE'RFF+CU:171577030'DTM+78:202002251709:203'LOC+14+7480:16::TRONDHEIM+NO:162'GID+1+1'PCI+30+370726206369762671'UNT+12+4'UNH+5+IFTSTA:D:04A:UN:BIG07'BGM+77+70726206369768672+9'DTM+137:202025021715:203'NAD+CZ+20000181410::87'CNI+1+70726206369768672'STS+1+Q::87:ARRIVED AT POST OFFICE'RFF+CU:171608297'DTM+78:202002251709:203'LOC+14+1442:16::DRBAK+NO:162'GID+1+1'PCI+30+370726206369768680'UNT+12+5'UNZ+5+20202502171538'`
+	benchDeclWithCompAndReleaseJSON = `
+{
+	"release_character": "?",
+	"element_delimiter": "+",
+	"component_delimiter": ":",
+	"segment_delimiter": "'",
+	"segment_declarations": [
+		{
+			"name": "UNA",
+			"child_segments": [
+				{ "name": "UNB" },
+				{
+					"name": "SG0", "type": "segment_group", "min": 0, "max": -1,
+					"child_segments": [
+						{ "name": "UNH" },
+						{ "name": "BGM" },
+						{ "name": "DTM", "min": 0 },
+						{
+							"name": "SG1_1", "type": "segment_group", "min": 0,
+							"child_segments": [
+								{ "name": "NAD" },
+								{
+									"name": "SG2", "type": "segment_group", "min": 0,
+									"child_segments": [
+										{ "name": "CTA" },
+										{ "name": "COM" }
+									]
+								}
+							]
+						},
+						{
+							"name": "SG1_2", "type": "segment_group", "min": 0,
+							"child_segments": [
+								{ "name": "NAD" }
+							]
+						},
+						{
+							"name": "SG4", "type": "segment_group", "is_target": true, "min": 0, "max": -1,
+							"child_segments": [
+								{
+									"name": "CNI",
+									"elements": [
+										{ "name": "tracking_number", "index": 2 }
+									]
+								},
+								{
+									"name": "SG5", "type": "segment_group", "max": -1,
+									"child_segments": [
+										{
+											"name": "STS", "min": 0,
+											"elements": [
+												{ "name": "status_code", "index":  2, "component_index": 1 },
+												{ "name": "description", "index":  2, "component_index":  4, "empty_if_missing": true }
+											]
+										},
+										{ "name": "RFF", "min": 0 },
+										{
+											"name": "DTM", "min": 0,
+											"elements": [
+												{ "name": "event_datetime", "index": 1, "component_index": 2, "empty_if_missing": true },
+												{ "name": "event_datetime_format", "index": 1, "component_index": 3, "empty_if_missing": true }
+											]
+										},
+										{ "name": "FTX", "min": 0 },
+										{
+											"name": "SG6", "type": "segment_group", "min": 0,
+											"child_segments": [
+												{ "name": "NAD" }
+											]
+										},
+										{
+											"name": "LOC", "min": 0,
+											"elements": [
+												{ "name": "city", "index": 2, "component_index": 4, "empty_if_missing": true },
+												{ "name": "country", "index": 3, "empty_if_missing": true }
+											]
+										},
+										{
+											"name": "SG14", "type": "segment_group", "min": 0,
+											"child_segments": [
+												{ "name": "GID" },
+												{
+													"name": "SG17", "type": "segment_group", "min": 0, "max": -1,
+													"child_segments": [
+														{ "name": "PCI" },
+														{ "name": "GIN", "min": 0 }
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{ "name": "UNT" }
+					]
+				},
+				{ "name": "UNZ" }
+			]
+		}
+	]
+}`
+)
+
+var (
+	benchDeclWithCompAndRelease = func() *fileDecl {
+		var fd fileDecl
+		err := json.Unmarshal([]byte(benchDeclWithCompAndReleaseJSON), &fd)
+		if err != nil {
+			panic(err)
+		}
+		return &fd
+	}()
+)
+
+// BenchmarkGetUnprocessedRawSeg_WithCompAndRelease-8    	    7077	    168176 ns/op	  227497 B/op	     816 allocs/op
+func BenchmarkGetUnprocessedRawSeg_WithCompAndRelease(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		reader := NewReader("test", strings.NewReader(benchInputWithCompAndRelease), benchDeclWithCompAndRelease)
 		for {
 			_, err := reader.getUnprocessedRawSeg()
 			if err == io.EOF {

--- a/extensions/omniv21/fileformat/edi/decl.go
+++ b/extensions/omniv21/fileformat/edi/decl.go
@@ -1,0 +1,9 @@
+package edi
+
+type fileDecl struct {
+	SegDelim    string     `json:"segment_delimiter,omitempty"`
+	ElemDelim   string     `json:"element_delimiter,omitempty"`
+	CompDelim   *string    `json:"component_delimiter,omitempty"`
+	ReleaseChar *string    `json:"release_character,omitempty"`
+	SegDecls    []*segDecl `json:"segment_declarations,omitempty"`
+}

--- a/extensions/omniv21/fileformat/edi/reader.go
+++ b/extensions/omniv21/fileformat/edi/reader.go
@@ -257,13 +257,6 @@ var (
 	ReaderBufSize = 128
 )
 
-func strPtrToBytes(s *string) []byte {
-	if s != nil {
-		return []byte(*s)
-	}
-	return nil
-}
-
 // NewReader creates an FormatReader for EDI file format.
 func NewReader(inputName string, r io.Reader, decl *fileDecl) *ediReader {
 	segDelim := newStrPtrByte(&decl.SegDelim)

--- a/extensions/omniv21/fileformat/edi/reader.go
+++ b/extensions/omniv21/fileformat/edi/reader.go
@@ -2,18 +2,40 @@ package edi
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io"
+	"unicode/utf8"
+
+	"github.com/jf-tech/go-corelib/ios"
+	"github.com/jf-tech/go-corelib/strs"
 
 	"github.com/jf-tech/omniparser/idr"
 )
 
+// ErrInvalidEDI indicates the EDI content is corrupted. This is a fatal, non-continuable error.
+type ErrInvalidEDI string
+
+func (e ErrInvalidEDI) Error() string { return string(e) }
+
+// IsErrInvalidEDI checks if an err is of ErrInvalidEDI type.
+func IsErrInvalidEDI(err error) bool {
+	switch err.(type) {
+	case ErrInvalidEDI:
+		return true
+	default:
+		return false
+	}
+}
+
 type rawSegElem struct {
-	elemIndex int // for this piece of data, the index of which element it belongs to. 1-based.
-	compIndex int // for this piece of data, the index of which component it belongs to. 1-based.
-	data      []byte
+	elemIndex int    // for this piece of data, the index of which element it belongs to. 1-based.
+	compIndex int    // for this piece of data, the index of which component it belongs to. 1-based.
+	data      []byte // READONLY elem/comp raw data (unescaped, so it might contain 'releaseChar' in it.
 }
 
 type rawSeg struct {
+	valid bool
 	name  string       // name of the segment, e.g. 'ISA', 'GS', etc.
 	raw   []byte       // the raw data of the entire segment, including segment delimiter.
 	elems []rawSegElem // all the broken down pieces of elements of the segment.
@@ -37,34 +59,45 @@ type stackEntry struct {
 }
 
 const (
-	defaultStackDepth = 50
+	defaultStackDepth = 10
 )
 
 func newStack() []stackEntry {
 	return make([]stackEntry, 0, defaultStackDepth)
 }
 
+type delim struct {
+	s string
+	b []byte
+	r []rune
+}
+
+func newDelim(s *string) *delim {
+	if s == nil {
+		return nil
+	}
+	return &delim{
+		s: *s,
+		b: []byte(*s),
+		r: []rune(*s),
+	}
+}
+
 type ediReader struct {
-	filename           string
+	inputName          string
 	scanner            *bufio.Scanner
-	segDelim           string
-	elemDelim          string
-	compDelim          *string
+	segDelim           delim
+	elemDelim          delim
+	compDelim          *delim
 	releaseChar        *rune
 	stack              []stackEntry
 	target             *idr.Node
-	runeCount          int
-	unprocessedSegData rawSeg
+	runeBegin, runeEnd int
+	unprocessedRawSeg  rawSeg
 }
 
 func inRange(i, lowerBoundInclusive, upperBoundInclusive int) bool {
 	return i >= lowerBoundInclusive && i <= upperBoundInclusive
-}
-
-func (r *ediReader) resetRawSeg() {
-	r.unprocessedSegData.name = ""
-	r.unprocessedSegData.raw = nil
-	r.unprocessedSegData.elems = r.unprocessedSegData.elems[:0]
 }
 
 // stackTop returns the pointer to the 'frame'-th stack entry from the top.
@@ -101,4 +134,154 @@ func (r *ediReader) shrinkStack() *stackEntry {
 // growStack adds a new stack entry to the top of the stack.
 func (r *ediReader) growStack(e stackEntry) {
 	r.stack = append(r.stack, e)
+}
+
+func (r *ediReader) resetRawSeg() {
+	r.unprocessedRawSeg.valid = false
+	r.unprocessedRawSeg.name = ""
+	r.unprocessedRawSeg.raw = nil
+	r.unprocessedRawSeg.elems = r.unprocessedRawSeg.elems[:0]
+}
+
+func runeCountAndHasOnlyCRLF(b []byte) (int, bool) {
+	runeCount := 0
+	onlyCRLF := true
+	for {
+		r, size := utf8.DecodeRune(b)
+		if r == utf8.RuneError {
+			return runeCount, onlyCRLF
+		}
+		if r != '\n' && r != '\r' {
+			onlyCRLF = false
+		}
+		runeCount++
+		b = b[size:]
+	}
+}
+
+func (r *ediReader) getUnprocessedRawSeg() (rawSeg, error) {
+	if r.unprocessedRawSeg.valid {
+		return r.unprocessedRawSeg, nil
+	}
+	var token []byte
+	for r.scanner.Scan() {
+		b := r.scanner.Bytes()
+		// In rare occasions inputs are not strict EDI per se - they sometimes have trailing empty lines
+		// with only CR and/or LF. Let's be not so strict and ignore those lines.
+		count, onlyCRLF := runeCountAndHasOnlyCRLF(b)
+		r.runeBegin = r.runeEnd
+		r.runeEnd += count
+		if onlyCRLF {
+			continue
+		}
+		token = b
+		break
+	}
+	// We are here because:
+	// 1. we find next token (i.e. segment), great, let's process it, OR
+	// 2. r.scanner.Scan() returns false and it's EOF (note scanner never returns EOF, it just returns false
+	//    on Scan() and Err() returns nil). We need to return EOF, OR
+	// 3. r.scanner.Scan() returns false Err() returns err, need to return the err wrapped.
+	err := r.scanner.Err()
+	if err != nil {
+		return rawSeg{}, ErrInvalidEDI(r.fmtErrStr("cannot read segment, err: %s", err.Error()))
+	}
+	if token == nil {
+		return rawSeg{}, io.EOF
+	}
+	// From now on, the important thing is to operate on token (of []byte)without modification and without
+	// allocation to keep performance.
+	r.unprocessedRawSeg.raw = token
+	// First we need to drop the trailing segment delimiter.
+	noSegDelim := token[:len(token)-len(r.segDelim.b)]
+	// In rare occasions, input uses '\n' as segment delimiter, but '\r' somehow
+	// gets included as well (more common in business platform running on Windows)
+	// Drop that '\r' as well.
+	if r.segDelim.s == "\n" && bytes.HasSuffix(noSegDelim, []byte{'\r'}) {
+		noSegDelim = noSegDelim[:len(noSegDelim)-utf8.RuneLen('\r')]
+	}
+	for i, elem := range r.split(noSegDelim, r.elemDelim, r.releaseChar) {
+		if r.compDelim == nil {
+			// if we don't have comp delimiter, treat the entire element as one component.
+			r.unprocessedRawSeg.elems = append(
+				r.unprocessedRawSeg.elems,
+				rawSegElem{
+					// while (element) index in schema starts with 1, it actually refers to the first element
+					// AFTER the seg name element, thus we use can i as elemIndex directly.
+					elemIndex: i,
+					// comp_index always starts with 1
+					compIndex: 1,
+					data:      elem,
+				})
+			continue
+		}
+		for j, comp := range r.split(elem, *r.compDelim, r.releaseChar) {
+			r.unprocessedRawSeg.elems = append(
+				r.unprocessedRawSeg.elems,
+				rawSegElem{
+					elemIndex: i,
+					compIndex: j + 1,
+					data:      comp,
+				})
+		}
+	}
+	if len(r.unprocessedRawSeg.elems) == 0 || len(r.unprocessedRawSeg.elems[0].data) == 0 {
+		return rawSeg{}, ErrInvalidEDI(r.fmtErrStr("segment is malformed, missing segment name"))
+	}
+	r.unprocessedRawSeg.name = string(r.unprocessedRawSeg.elems[0].data)
+	r.unprocessedRawSeg.valid = true
+	return r.unprocessedRawSeg, nil
+}
+
+func (r *ediReader) split(s []byte, delim delim, esc *rune) [][]byte {
+	if esc == nil {
+		return bytes.Split(s, delim.b)
+	}
+	return strs.ByteSplitWithEsc(s, delim.r, *esc, defaultElemsPerSeg)
+}
+
+func (r *ediReader) fmtErrStr(format string, args ...interface{}) string {
+	return fmt.Sprintf("input '%s' between character [%d,%d]: %s",
+		r.inputName, r.runeBegin, r.runeEnd, fmt.Sprintf(format, args...))
+}
+
+const (
+	scannerFlags = ios.ScannerByDelimFlagEofNotAsDelim | ios.ScannerByDelimFlagIncludeDelimInReturn
+)
+
+var (
+	// Default buf size for EDI reader. Making it too small might increase mem-alloc and gc;
+	// making it too big increases the initial memory consumption footprint (unnecessarily)
+	// for each reader creation which eventually leads to gc as well.
+	// Make it exported so caller can experiment and set their optimal value.
+	ReaderBufSize = 128
+)
+
+// NewReader creates an FormatReader for EDI file format.
+func NewReader(inputName string, r io.Reader, decl *fileDecl) *ediReader {
+	releaseChar := (*rune)(nil)
+	if decl.ReleaseChar != nil && len([]rune(*decl.ReleaseChar)) > 0 {
+		releaseChar = strs.RunePtr([]rune(*decl.ReleaseChar)[0])
+	}
+	reader := &ediReader{
+		inputName:         inputName,
+		scanner:           ios.NewScannerByDelim3(r, decl.SegDelim, releaseChar, scannerFlags, make([]byte, ReaderBufSize)),
+		segDelim:          *newDelim(&decl.SegDelim),
+		elemDelim:         *newDelim(&decl.ElemDelim),
+		compDelim:         newDelim(decl.CompDelim),
+		releaseChar:       releaseChar,
+		stack:             newStack(),
+		runeBegin:         1,
+		runeEnd:           1,
+		unprocessedRawSeg: newRawSeg(),
+	}
+	reader.growStack(stackEntry{
+		segDecl: &segDecl{
+			Name:     rootSegName,
+			Type:     strs.StrPtr(segTypeGroup),
+			Children: decl.SegDecls,
+			fqdn:     rootSegName,
+		},
+	})
+	return reader
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/uuid v1.1.2
-	github.com/jf-tech/go-corelib v0.0.4
+	github.com/jf-tech/go-corelib v0.0.7
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/uuid v1.1.2
-	github.com/jf-tech/go-corelib v0.0.7
+	github.com/jf-tech/go-corelib v0.0.8
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jf-tech/go-corelib v0.0.7 h1:OrQLto3CtKECnbeHy5+9IM1XL4vfWJceuRdbpGjIRCo=
-github.com/jf-tech/go-corelib v0.0.7/go.mod h1:0+Fejzd53JtexKE5VI8I06WiBNATLIURRJgPrv4Yysg=
+github.com/jf-tech/go-corelib v0.0.8 h1:zlhJBWWVwaFAGhzNLylyqdDMb/6mt3rhrr8QQZxQi2I=
+github.com/jf-tech/go-corelib v0.0.8/go.mod h1:0+Fejzd53JtexKE5VI8I06WiBNATLIURRJgPrv4Yysg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jf-tech/go-corelib v0.0.4 h1:XP5w5bumH/zR6/EZGzD4webeZ1BPU62xZvraAiyIqdc=
-github.com/jf-tech/go-corelib v0.0.4/go.mod h1:0+Fejzd53JtexKE5VI8I06WiBNATLIURRJgPrv4Yysg=
+github.com/jf-tech/go-corelib v0.0.7 h1:OrQLto3CtKECnbeHy5+9IM1XL4vfWJceuRdbpGjIRCo=
+github.com/jf-tech/go-corelib v0.0.7/go.mod h1:0+Fejzd53JtexKE5VI8I06WiBNATLIURRJgPrv4Yysg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
The implementation tries to minimize allocation/reallocation induced by conversions among `string<->[]rune<->[]byte`.
Benchmark shows significant improvement (~4x to ~5x in latency reduction in general and ~20x in memory alloc reduction in most popular scenario that input has no comp-delim nor release-char) 
- most popular scenario: no comp-delim and no release-char:
```
old: BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar-8   3000  389955 ns/op  558626 B/op  3024 allocs/op
new: BenchmarkGetUnprocessedRawSeg_NoCompNoReleaseChar-8  10000  103945 ns/op   27080 B/op   515 allocs/op
```

- most complex scenario: comp-delim + release-char:
```
old: BenchmarkGetUnprocessedRawSeg_WithCompAndRelease-8    3000  402042 ns/op  397383 B/op  1857 allocs/op
new: BenchmarkGetUnprocessedRawSeg_WithCompAndRelease-8   14174   84115 ns/op  102880 B/op   385 allocs/op
```