### PR TITLE
add `ediReader.rawSegToNode`

### DIFF
--- a/extensions/omniv21/fileformat/edi/reader_test.go
+++ b/extensions/omniv21/fileformat/edi/reader_test.go
@@ -306,7 +306,7 @@ func TestGetUnprocessedRawSeg(t *testing.T) {
 }
 
 func TestRawSegToNode(t *testing.T) {
-	assert.PanicsWithValue(t, "invalid state - unprocessedRawSeg is not valid", func() {
+	assert.PanicsWithValue(t, "unprocessedRawSeg is not valid", func() {
 		_, _ = (&ediReader{unprocessedRawSeg: rawSeg{valid: false}}).rawSegToNode(nil)
 	})
 
@@ -377,11 +377,13 @@ func TestRawSegToNode(t *testing.T) {
 					{Name: "e2c1", Index: 2, CompIndex: testlib.IntPtr(1)},
 					{Name: "e2c2", Index: 2, CompIndex: testlib.IntPtr(2)},
 					{Name: "e3", Index: 3},
+					{Name: "e4", Index: 4, EmptyIfMissing: true},
+					{Name: "e5", Index: 5, EmptyIfMissing: true},
 				},
 				fqdn: "ISA",
 			},
 			err:      "",
-			expected: `{"e1":"0","e2c1":"1","e2c2":"2","e3":"3*"}`,
+			expected: `{"e1":"0","e2c1":"1","e2c2":"2","e3":"3*","e4":"","e5":""}`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/extensions/omniv21/fileformat/edi/seg.go
+++ b/extensions/omniv21/fileformat/edi/seg.go
@@ -36,15 +36,23 @@ type elem struct {
 	EmptyIfMissing bool   `json:"empty_if_missing,omitempty"`
 }
 
+func (e elem) compIndex() int {
+	if e.CompIndex == nil {
+		return 1
+	}
+	return *e.CompIndex
+}
+
 type segDecl struct {
-	Name     string     `json:"name,omitempty"`
-	Type     *string    `json:"type,omitempty"`
-	IsTarget bool       `json:"is_target,omitempty"`
-	Min      *int       `json:"min,omitempty"`
-	Max      *int       `json:"max,omitempty"`
-	Elems    []elem     `json:"elements,omitempty"`
-	Children []*segDecl `json:"child_segments,omitempty"`
-	fqdn     string     // internal computed field
+	Name               string     `json:"name,omitempty"`
+	Type               *string    `json:"type,omitempty"`
+	IsTarget           bool       `json:"is_target,omitempty"`
+	FixedLengthInBytes *int       `json:"fixed_length_in_bytes,omitempty"`
+	Min                *int       `json:"min,omitempty"`
+	Max                *int       `json:"max,omitempty"`
+	Elems              []elem     `json:"elements,omitempty"`
+	Children           []*segDecl `json:"child_segments,omitempty"`
+	fqdn               string     // internal computed field
 }
 
 func (d *segDecl) isGroup() bool {

--- a/extensions/omniv21/fileformat/edi/seg_test.go
+++ b/extensions/omniv21/fileformat/edi/seg_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestElemCompIndex(t *testing.T) {
+	assert.Equal(t, 1, elem{}.compIndex())
+	assert.Equal(t, 123, elem{CompIndex: testlib.IntPtr(123)}.compIndex())
+}
+
 func TestSegDeclIsGroup(t *testing.T) {
 	assert.False(t, (&segDecl{}).isGroup())
 	assert.False(t, (&segDecl{Type: strs.StrPtr(segTypeSeg)}).isGroup())

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/uuid v1.1.2
-	github.com/jf-tech/go-corelib v0.0.8
+	github.com/jf-tech/go-corelib v0.0.9-0.20201025035420-73dc5cca9a65
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jf-tech/go-corelib v0.0.8 h1:zlhJBWWVwaFAGhzNLylyqdDMb/6mt3rhrr8QQZxQi2I=
-github.com/jf-tech/go-corelib v0.0.8/go.mod h1:0+Fejzd53JtexKE5VI8I06WiBNATLIURRJgPrv4Yysg=
+github.com/jf-tech/go-corelib v0.0.9-0.20201025035420-73dc5cca9a65 h1:8a1MlR0JGayXN69eFwgWEQAs6Tnz/3UmHCgotzBpDHI=
+github.com/jf-tech/go-corelib v0.0.9-0.20201025035420-73dc5cca9a65/go.mod h1:0+Fejzd53JtexKE5VI8I06WiBNATLIURRJgPrv4Yysg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
converts a `rawSeg` into an `idr.Node` based on a `segDecl`