### PR TITLE
Adding EDI `file_declaration` json schema

### DIFF
--- a/extensions/omniv21/validation/csvFileDeclaration.go
+++ b/extensions/omniv21/validation/csvFileDeclaration.go
@@ -6,42 +6,37 @@ const (
     JSONSchemaCSVFileDeclaration =
 `
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "github.com/jf-tech/omniparser:csv_file_declaration",
-  "title": "omniparser schema: csv/file_declaration",
-  "type": "object",
-  "properties": {
-    "file_declaration": {
-      "type": "object",
-      "properties": {
-        "delimiter": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 1
-        },
-        "replace_double_quotes": { "type": "boolean" },
-        "header_row_index": { "type": "integer", "minimum": 1 },
-        "data_row_index": { "type": "integer", "minimum": 1 },
-        "columns": {
-          "type": "array",
-          "items": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "github.com/jf-tech/omniparser:csv_file_declaration",
+    "title": "omniparser schema: csv/file_declaration",
+    "type": "object",
+    "properties": {
+        "file_declaration": {
             "type": "object",
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "alias": { "type": "string", "pattern": "^[_a-zA-Z0-9]+$" }
+                "delimiter": { "type": "string", "minLength": 1, "maxLength": 1 },
+                "replace_double_quotes": { "type": "boolean" },
+                "header_row_index": { "type": "integer", "minimum": 1 },
+                "data_row_index": { "type": "integer", "minimum": 1 },
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string", "minLength": 1 },
+                            "alias": { "type": "string", "pattern": "^[_a-zA-Z0-9]+$" }
+                        },
+                        "required": [ "name" ],
+                        "additionalProperties": false
+                    },
+                    "minItems": 1
+                }
             },
-            "required": [ "name" ],
+            "required": [ "delimiter", "data_row_index", "columns" ],
             "additionalProperties": false
-          },
-          "minItems": 1
         }
-      },
-      "required": [ "delimiter", "data_row_index", "columns" ],
-      "additionalProperties": false
-    }
-  },
-  "required": [ "file_declaration" ]
+    },
+    "required": [ "file_declaration" ]
 }
-
 `
 )

--- a/extensions/omniv21/validation/csv_file_declaration.json
+++ b/extensions/omniv21/validation/csv_file_declaration.json
@@ -1,37 +1,33 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "github.com/jf-tech/omniparser:csv_file_declaration",
-  "title": "omniparser schema: csv/file_declaration",
-  "type": "object",
-  "properties": {
-    "file_declaration": {
-      "type": "object",
-      "properties": {
-        "delimiter": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 1
-        },
-        "replace_double_quotes": { "type": "boolean" },
-        "header_row_index": { "type": "integer", "minimum": 1 },
-        "data_row_index": { "type": "integer", "minimum": 1 },
-        "columns": {
-          "type": "array",
-          "items": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "github.com/jf-tech/omniparser:csv_file_declaration",
+    "title": "omniparser schema: csv/file_declaration",
+    "type": "object",
+    "properties": {
+        "file_declaration": {
             "type": "object",
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "alias": { "type": "string", "pattern": "^[_a-zA-Z0-9]+$" }
+                "delimiter": { "type": "string", "minLength": 1, "maxLength": 1 },
+                "replace_double_quotes": { "type": "boolean" },
+                "header_row_index": { "type": "integer", "minimum": 1 },
+                "data_row_index": { "type": "integer", "minimum": 1 },
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string", "minLength": 1 },
+                            "alias": { "type": "string", "pattern": "^[_a-zA-Z0-9]+$" }
+                        },
+                        "required": [ "name" ],
+                        "additionalProperties": false
+                    },
+                    "minItems": 1
+                }
             },
-            "required": [ "name" ],
+            "required": [ "delimiter", "data_row_index", "columns" ],
             "additionalProperties": false
-          },
-          "minItems": 1
         }
-      },
-      "required": [ "delimiter", "data_row_index", "columns" ],
-      "additionalProperties": false
-    }
-  },
-  "required": [ "file_declaration" ]
+    },
+    "required": [ "file_declaration" ]
 }

--- a/extensions/omniv21/validation/ediFileDeclaration.go
+++ b/extensions/omniv21/validation/ediFileDeclaration.go
@@ -1,0 +1,69 @@
+// Code generated - DO NOT EDIT.
+
+package validation
+
+const (
+    JSONSchemaEDIFileDeclaration =
+`
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "github.com/jf-tech/omniparser:edi_file_declaration",
+    "title": "omniparser schema: edi/file_declaration",
+    "type": "object",
+    "properties": {
+        "file_declaration": {
+            "type": "object",
+            "properties": {
+                "segment_delimiter": { "type": "string", "minLength": 1 },
+                "element_delimiter": { "type": "string", "minLength": 1 },
+                "component_delimiter": { "type": "string", "minLength": 1 },
+                "release_character": { "type": "string", "minLength": 1 },
+                "segment_declarations": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/segment_declaration_type"
+                    }
+                }
+            },
+            "required": [ "segment_delimiter", "element_delimiter", "segment_declarations" ],
+            "additionalProperties": false
+        }
+    },
+    "required": [ "file_declaration" ],
+    "definitions": {
+        "segment_declaration_type": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "minLength": 1 },
+                "type": { "type": "string", "enum": [ "segment", "segment_group" ] },
+                "is_target": { "type": "boolean" },
+                "min": { "type": "integer", "minimum": 0 },
+                "max": { "type": "integer", "minimum": -1 },
+                "elements": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string", "minLength": 1 },
+                            "index": { "type": "integer", "minimum": 1 },
+                            "component_index": { "type": "integer", "minimum": 1 },
+                            "empty_if_missing": { "type": "boolean" }
+                        },
+                        "required": [ "name", "index" ],
+                        "additionalProperties": false
+                    }
+                },
+                "child_segments": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/segment_declaration_type"
+                    }
+                }
+            },
+            "required": [ "name" ],
+            "additionalProperties": false
+        }
+    }
+}
+`
+)

--- a/extensions/omniv21/validation/edi_file_declaration.json
+++ b/extensions/omniv21/validation/edi_file_declaration.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "github.com/jf-tech/omniparser:edi_file_declaration",
+    "title": "omniparser schema: edi/file_declaration",
+    "type": "object",
+    "properties": {
+        "file_declaration": {
+            "type": "object",
+            "properties": {
+                "segment_delimiter": { "type": "string", "minLength": 1 },
+                "element_delimiter": { "type": "string", "minLength": 1 },
+                "component_delimiter": { "type": "string", "minLength": 1 },
+                "release_character": { "type": "string", "minLength": 1 },
+                "segment_declarations": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/segment_declaration_type"
+                    }
+                }
+            },
+            "required": [ "segment_delimiter", "element_delimiter", "segment_declarations" ],
+            "additionalProperties": false
+        }
+    },
+    "required": [ "file_declaration" ],
+    "definitions": {
+        "segment_declaration_type": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "minLength": 1 },
+                "type": { "type": "string", "enum": [ "segment", "segment_group" ] },
+                "is_target": { "type": "boolean" },
+                "min": { "type": "integer", "minimum": 0 },
+                "max": { "type": "integer", "minimum": -1 },
+                "elements": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string", "minLength": 1 },
+                            "index": { "type": "integer", "minimum": 1 },
+                            "component_index": { "type": "integer", "minimum": 1 },
+                            "empty_if_missing": { "type": "boolean" }
+                        },
+                        "required": [ "name", "index" ],
+                        "additionalProperties": false
+                    }
+                },
+                "child_segments": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/segment_declaration_type"
+                    }
+                }
+            },
+            "required": [ "name" ],
+            "additionalProperties": false
+        }
+    }
+}

--- a/extensions/omniv21/validation/jsonvalidate.go
+++ b/extensions/omniv21/validation/jsonvalidate.go
@@ -2,3 +2,4 @@ package validation
 
 //go:generate sh -c "go run ../../../validation/gen/gen.go -json transform_declarations.json -varname JSONSchemaTransformDeclarations > ./transformDeclarations.go"
 //go:generate sh -c "go run ../../../validation/gen/gen.go -json csv_file_declaration.json -varname JSONSchemaCSVFileDeclaration > ./csvFileDeclaration.go"
+//go:generate sh -c "go run ../../../validation/gen/gen.go -json edi_file_declaration.json -varname JSONSchemaEDIFileDeclaration > ./ediFileDeclaration.go"


### PR DESCRIPTION
The diffs from previous generation:
- `fixed_length_in_bytes` is gone: in practice, never used it once. Why bother adding it here.
- `release_character`'s `maxLength: 1` is gone: now our library code is more capable (and surprisingly much faster) to deal with esc whose len>1.