### PR TITLE
Fix a bug in edireader a missing optional elem would cause subsequent elem parsing fail

### DIFF
--- a/extensions/omniv21/fileformat/edi/.snapshots/TestValidateSchema-success
+++ b/extensions/omniv21/fileformat/edi/.snapshots/TestValidateSchema-success
@@ -8,12 +8,12 @@
 				"is_target": true,
 				"elements": [
 					{
-						"name": "e1",
-						"index": 1
-					},
-					{
 						"name": "e2",
 						"index": 2
+					},
+					{
+						"name": "e1",
+						"index": 1
 					}
 				]
 			}

--- a/extensions/omniv21/fileformat/edi/reader.go
+++ b/extensions/omniv21/fileformat/edi/reader.go
@@ -250,10 +250,9 @@ func (r *ediReader) rawSegToNode(segDecl *segDecl) (*idr.Node, error) {
 		panic("unprocessedRawSeg is not valid")
 	}
 	n := idr.CreateNode(idr.ElementNode, segDecl.Name)
-	// Note: we assume segDecl.Elems are sorted by elemIndex/compIndex.
-	rawElemIndex := 0
 	rawElems := r.unprocessedRawSeg.elems
 	for _, elemDecl := range segDecl.Elems {
+		rawElemIndex := 0
 		for ; rawElemIndex < len(rawElems); rawElemIndex++ {
 			if rawElems[rawElemIndex].elemIndex == elemDecl.Index &&
 				rawElems[rawElemIndex].compIndex == elemDecl.compIndex() {

--- a/extensions/omniv21/fileformat/edi/validate.go
+++ b/extensions/omniv21/fileformat/edi/validate.go
@@ -3,7 +3,6 @@ package edi
 import (
 	"errors"
 	"fmt"
-	"sort"
 
 	"github.com/jf-tech/go-corelib/strs"
 )
@@ -36,7 +35,6 @@ func (ctx *ediValidateCtx) validateSegDecl(segFQDN string, segDecl *segDecl) err
 		}
 		ctx.seenTarget = true
 	}
-	ctx.sortElems(segFQDN, segDecl.Elems)
 	if segDecl.isGroup() && len(segDecl.Children) <= 0 {
 		return fmt.Errorf("segment_group '%s' must have at least one child segment/segment_group", segFQDN)
 	}
@@ -47,13 +45,4 @@ func (ctx *ediValidateCtx) validateSegDecl(segFQDN string, segDecl *segDecl) err
 		}
 	}
 	return nil
-}
-
-func (ctx *ediValidateCtx) sortElems(segFQDN string, elems []elem) {
-	// For now there is no validation for []elem. The only validation time processing we need to
-	// do is to ensure Index/CompIndex are sorted.
-	sort.SliceStable(elems, func(i, j int) bool {
-		return elems[i].Index < elems[j].Index ||
-			(elems[i].Index == elems[j].Index && elems[i].compIndex() < elems[j].compIndex())
-	})
 }

--- a/extensions/omniv21/fileformat/edi/validate_test.go
+++ b/extensions/omniv21/fileformat/edi/validate_test.go
@@ -8,23 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func collectSegDeclsFQDNs(segDecls []*segDecl) map[string]interface{} {
-	if len(segDecls) == 0 {
-		return nil
-	}
-	m := map[string]interface{}{}
-	for _, seg := range segDecls {
-		m[seg.Name] = struct {
-			FQDN     string
-			Children map[string]interface{}
-		}{
-			FQDN:     seg.fqdn,
-			Children: collectSegDeclsFQDNs(seg.Children),
-		}
-	}
-	return m
-}
-
 func TestValidateFileDecl_Empty(t *testing.T) {
 	err := (&ediValidateCtx{}).validateFileDecl(&fileDecl{})
 	assert.Error(t, err)
@@ -78,5 +61,5 @@ func TestValidateFileDecl_Success(t *testing.T) {
 	assert.Equal(t, "A", fd.SegDecls[0].fqdn)
 	assert.Nil(t, fd.SegDecls[0].Elems)
 	assert.Equal(t, "A/B", fd.SegDecls[0].Children[0].fqdn)
-	assert.Equal(t, []elem{elem1, elem2, elem3}, fd.SegDecls[0].Children[0].Elems)
+	assert.Equal(t, []elem{elem3, elem1, elem2}, fd.SegDecls[0].Children[0].Elems)
 }


### PR DESCRIPTION
Imagine a seg `ISA*e2` (elem delim is `'*'`). Imagine the elem decl is:

```
    { "name": "e1", "index": 1, "empty_if_missing": true },
    { "name": "e2", "index": 2 }
```

Now e1 is optional, thus schema writer specifies "empty_if_missing". However the current single-linear-scan
in `ediReader.rawSegToNode` will scan all the way to the end, thus causing the subsequent `e2` scanning to
fail.