### PR TITLE
Change the `Transform` coding pattern from `Next() -> Read()` to just `Read()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ Take a detailed look at samples here:
     if err != nil { ... }
     transform, err := schema.NewTransform("input-name", strings.NewReader("..."), &transformctx.Ctx{})
     if err != nil { ... }
-    if !transform.Next() { ... }  
-    b, err := transform.Read()
-    if err != nil { ... }
-    fmt.Println(string(b))
+    for {
+        b, err := transform.Read()
+        if err == io.EOF { break }
+        if err != nil { ... }
+        fmt.Println(string(b))
+    }
     ```
 - Output:
     ```
@@ -115,7 +117,7 @@ Take a detailed look at samples here:
 ## Requirements
 - Golang 1.14
 
-## Recent Feature Additions
+## Recent Major Feature Additions/Changes
 - Added EDI file format support in omniv2 handler.
 - Major restructure/refactoring
     - Upgrade omni schema version to `omni.2.1` due a number of incompatible schema changes:

--- a/cli/cmd/serverCmd.go
+++ b/cli/cmd/serverCmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -136,8 +137,11 @@ func httpPostTransform(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var records []string
-	for t.Next() {
+	for {
 		b, err := t.Read()
+		if err == io.EOF {
+			break
+		}
 		if err != nil {
 			writeBadRequest(w, fmt.Sprintf("bad request: transform failed. err: %s", err))
 			return

--- a/extensions/omniv21/samples/csv/csv_test.go
+++ b/extensions/omniv21/samples/csv/csv_test.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -48,8 +49,11 @@ func Benchmark1_Weather_Data_CSV(b *testing.B) {
 		if err != nil {
 			b.FailNow()
 		}
-		for transform.Next() {
+		for {
 			_, err := transform.Read()
+			if err == io.EOF {
+				break
+			}
 			if err != nil {
 				b.FailNow()
 			}

--- a/extensions/omniv21/samples/customfileformats/jsonlog/sample_test.go
+++ b/extensions/omniv21/samples/customfileformats/jsonlog/sample_test.go
@@ -1,6 +1,7 @@
 package jsonlog
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,8 +77,11 @@ func TestSample(t *testing.T) {
 	assert.NoError(t, err)
 
 	var records []string
-	for transform.Next() {
+	for {
 		recordBytes, err := transform.Read()
+		if err == io.EOF {
+			break
+		}
 		assert.NoError(t, err)
 		records = append(records, string(recordBytes))
 	}

--- a/extensions/omniv21/samples/customparse/sample_test.go
+++ b/extensions/omniv21/samples/customparse/sample_test.go
@@ -1,6 +1,7 @@
 package customparse
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -45,12 +46,15 @@ func TestSample(t *testing.T) {
 			},
 		})
 	assert.NoError(t, err)
-	tfm, err := schema.NewTransform(inputFileBaseName, inputFileReader, &transformctx.Ctx{})
+	transform, err := schema.NewTransform(inputFileBaseName, inputFileReader, &transformctx.Ctx{})
 	assert.NoError(t, err)
 
 	var records []string
-	for tfm.Next() {
-		recordBytes, err := tfm.Read()
+	for {
+		recordBytes, err := transform.Read()
+		if err == io.EOF {
+			break
+		}
 		assert.NoError(t, err)
 		records = append(records, string(recordBytes))
 	}

--- a/extensions/omniv21/samples/edi/edi_test.go
+++ b/extensions/omniv21/samples/edi/edi_test.go
@@ -2,6 +2,7 @@ package edi
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -45,8 +46,11 @@ func Benchmark1_CanadaPost_EDI_214(b *testing.B) {
 		if err != nil {
 			b.FailNow()
 		}
-		for transform.Next() {
+		for {
 			_, err := transform.Read()
+			if err == io.EOF {
+				break
+			}
 			if err != nil {
 				b.FailNow()
 			}

--- a/extensions/omniv21/samples/json/json_test.go
+++ b/extensions/omniv21/samples/json/json_test.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"testing"
 
@@ -58,8 +59,11 @@ func Benchmark2_Multiple_Objects(b *testing.B) {
 		if err != nil {
 			b.FailNow()
 		}
-		for transform.Next() {
+		for {
 			_, err := transform.Read()
+			if err == io.EOF {
+				break
+			}
 			if err != nil {
 				b.FailNow()
 			}

--- a/extensions/omniv21/samples/testCommon.go
+++ b/extensions/omniv21/samples/testCommon.go
@@ -1,6 +1,7 @@
 package samples
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,11 +31,13 @@ func SampleTestCommon(t *testing.T, schemaFile, inputFile string) string {
 	assert.NoError(t, err)
 
 	var records []string
-	for transform.Next() {
+	for {
 		recordBytes, err := transform.Read()
+		if err == io.EOF {
+			break
+		}
 		assert.NoError(t, err)
 		records = append(records, string(recordBytes))
 	}
-
 	return "[" + strings.Join(records, ",") + "]"
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -53,31 +53,26 @@ func TestTransform_EndWithEOF(t *testing.T) {
 			continuableErrs: map[error]bool{continuableErr1: true},
 		},
 	}
-	assert.True(t, tfm.Next())
 	record, err := tfm.Read()
 	assert.NoError(t, err)
 	assert.Equal(t, "1st good read", string(record))
 
-	assert.True(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.Error(t, err)
 	assert.True(t, errs.IsErrTransformFailed(err))
 	assert.Equal(t, continuableErr1.Error(), err.Error())
 	assert.Nil(t, record)
 
-	assert.True(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.NoError(t, err)
 	assert.Equal(t, "2nd good read", string(record))
 
-	assert.False(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.Error(t, err)
 	assert.Equal(t, io.EOF, err)
 	assert.Nil(t, record)
 
 	// Verifying when EOF is reached, repeatedly calling Next will still get you EOF.
-	assert.False(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.Error(t, err)
 	assert.Equal(t, io.EOF, err)
@@ -93,12 +88,10 @@ func TestTransform_EndWithNonContinuableError(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, tfm.Next())
 	record, err := tfm.Read()
 	assert.NoError(t, err)
 	assert.Equal(t, "1st good read", string(record))
 
-	assert.True(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.Error(t, err)
 	assert.False(t, errs.IsErrTransformFailed(err))
@@ -106,7 +99,6 @@ func TestTransform_EndWithNonContinuableError(t *testing.T) {
 	assert.Nil(t, record)
 
 	// Verifying when fatal error occurred, repeatedly calling Next/Read will still get you the same err
-	assert.False(t, tfm.Next())
 	record, err = tfm.Read()
 	assert.Error(t, err)
 	assert.Equal(t, "fatal error", err.Error())


### PR DESCRIPTION
Found this `Next()->Read()` pattern pretty silly and unnecessary. Also current `Next()` has a useless `for {}` wrapping loop. Probably from long time ago, but it's not needed.