### PR TITLE
supports a "segment_prefix" in the edi parser file declaration

### DIFF
--- a/extensions/omniv21/fileformat/edi/decl.go
+++ b/extensions/omniv21/fileformat/edi/decl.go
@@ -6,6 +6,7 @@ type FileDecl struct {
 	ElemDelim   string     `json:"element_delimiter,omitempty"`
 	CompDelim   *string    `json:"component_delimiter,omitempty"`
 	ReleaseChar *string    `json:"release_character,omitempty"`
+	SegPrefix   *string    `json:"segment_prefix,omitempty"`
 	IgnoreCRLF  bool       `json:"ignore_crlf,omitempty"`
 	SegDecls    []*SegDecl `json:"segment_declarations,omitempty"`
 }

--- a/extensions/omniv21/validation/ediFileDeclaration.go
+++ b/extensions/omniv21/validation/ediFileDeclaration.go
@@ -3,8 +3,7 @@
 package validation
 
 const (
-    JSONSchemaEDIFileDeclaration =
-`
+	JSONSchemaEDIFileDeclaration = `
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "github.com/jf-tech/omniparser:edi_file_declaration",
@@ -18,6 +17,7 @@ const (
                 "element_delimiter": { "type": "string", "minLength": 1 },
                 "component_delimiter": { "type": "string", "minLength": 1 },
                 "release_character": { "type": "string", "minLength": 1 },
+                "segment_prefix": { "type": "string", "minLength": 1 },
                 "ignore_crlf": { "type": "boolean" },
                 "segment_declarations": {
                     "type": "array",

--- a/extensions/omniv21/validation/ediFileDeclaration.json
+++ b/extensions/omniv21/validation/ediFileDeclaration.json
@@ -11,6 +11,7 @@
                 "element_delimiter": { "type": "string", "minLength": 1 },
                 "component_delimiter": { "type": "string", "minLength": 1 },
                 "release_character": { "type": "string", "minLength": 1 },
+                "segment_prefix": { "type": "string", "minLength": 1 },
                 "ignore_crlf": { "type": "boolean" },
                 "segment_declarations": {
                     "type": "array",


### PR DESCRIPTION
I'm working with a non-standard EDI format that includes a segment prefix. For example, a message might be:

```
|HDR|1|2|3|
|DAT|X|
|EOF|
```

where every segment begins with a pipe. I thought that I could get around this by making the segment delimiter include the  next pipe (ie `|\n|`), but this doesn't catch the very first pipe.

I propose including a new (optional) "segment_prefix" field in the file_declaration to catch segment prefixes.