### PR TITLE
Adding flatfile.HierarchyReader which is closely modeled after edi.reader but with more abstraction with the use of RecReader.

### DIFF
--- a/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-B,_B_recDone,_moves_to_C,_no_target
+++ b/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-B,_B_recDone,_moves_to_C,_no_target
@@ -1,0 +1,23 @@
+{
+	"Stack": [
+		{
+			"RecDecl": "#root",
+			"RecNode": "#root",
+			"CurChild": 0,
+			"Occurred": 0
+		},
+		{
+			"RecDecl": "A",
+			"RecNode": "A",
+			"CurChild": 1,
+			"Occurred": 0
+		},
+		{
+			"RecDecl": "C",
+			"RecNode": null,
+			"CurChild": 0,
+			"Occurred": 0
+		}
+	],
+	"Target": null
+}

--- a/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-C,_C_recDone,_C_over_max,_A_becomes_target
+++ b/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-C,_C_recDone,_C_over_max,_A_becomes_target
@@ -1,0 +1,17 @@
+{
+	"Stack": [
+		{
+			"RecDecl": "#root",
+			"RecNode": "#root",
+			"CurChild": 0,
+			"Occurred": 0
+		},
+		{
+			"RecDecl": "A",
+			"RecNode": "A",
+			"CurChild": 0,
+			"Occurred": 1
+		}
+	],
+	"Target": "A"
+}

--- a/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-C,_C_recDone,_C_over_max,_A_becomes_target,_but_target_xpath_no_match
+++ b/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-C,_C_recDone,_C_over_max,_A_becomes_target,_but_target_xpath_no_match
@@ -1,0 +1,17 @@
+{
+	"Stack": [
+		{
+			"RecDecl": "#root",
+			"RecNode": "#root",
+			"CurChild": 0,
+			"Occurred": 0
+		},
+		{
+			"RecDecl": "A",
+			"RecNode": null,
+			"CurChild": 0,
+			"Occurred": 1
+		}
+	],
+	"Target": null
+}

--- a/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-C,_C_recDone,_stay,_no_target
+++ b/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-A-C,_C_recDone,_stay,_no_target
@@ -1,0 +1,23 @@
+{
+	"Stack": [
+		{
+			"RecDecl": "#root",
+			"RecNode": "#root",
+			"CurChild": 0,
+			"Occurred": 0
+		},
+		{
+			"RecDecl": "A",
+			"RecNode": "A",
+			"CurChild": 1,
+			"Occurred": 0
+		},
+		{
+			"RecDecl": "C",
+			"RecNode": "C",
+			"CurChild": 0,
+			"Occurred": 1
+		}
+	],
+	"Target": null
+}

--- a/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-D,_D_recDone
+++ b/extensions/omniv21/fileformat/flatfile/.snapshots/TestRecDoneRecNext-root-D,_D_recDone
@@ -1,0 +1,11 @@
+{
+	"Stack": [
+		{
+			"RecDecl": "#root",
+			"RecNode": "#root",
+			"CurChild": 0,
+			"Occurred": 1
+		}
+	],
+	"Target": null
+}

--- a/extensions/omniv21/fileformat/flatfile/hierarchyReader.go
+++ b/extensions/omniv21/fileformat/flatfile/hierarchyReader.go
@@ -1,0 +1,312 @@
+package flatfile
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/antchfx/xpath"
+
+	"github.com/jf-tech/omniparser/idr"
+)
+
+// HierarchyReader orchestrates reading, matching, and converting (to IDR) of
+// data streams of various flat file formats that (potentially) contain hierarchically
+// structured records.
+type HierarchyReader struct {
+	r               RecReader
+	stack           []stackEntry
+	target          *idr.Node
+	targetXPathExpr *xpath.Expr
+}
+
+// NewHierarchyReader creates a new instance of a HierarchyReader.
+func NewHierarchyReader(
+	decls []RecDecl, recReader RecReader, targetXPathExpr *xpath.Expr) *HierarchyReader {
+	r := &HierarchyReader{
+		r:               recReader,
+		stack:           make([]stackEntry, 0, initialStackDepth),
+		targetXPathExpr: targetXPathExpr,
+	}
+	rootDecl := rootDecl{children: decls}
+	r.growStack(stackEntry{
+		recDecl: rootDecl,
+		recNode: idr.CreateNode(idr.DocumentNode, rootDecl.DeclName()),
+	})
+	if len(rootDecl.children) > 0 {
+		r.growStack(stackEntry{recDecl: rootDecl.children[0]})
+	}
+	return r
+}
+
+// Read orchestrates reading, matching, and converting (to IDR) of a data stream of
+// a flat file format. Possible return values:
+// - (node, nil): a target node has been fetched successfully, ready for transformation.
+// - (nil, io.EOF): no more data to read, all operations completed successfully.
+// - (nil, ErrFewerThanMinOccurs): a record decl requires a min occurs but isn't satisified
+//   by the data stream.
+// - (nil, ErrUnexpectedData): some unknown/unexpected data encountered that isn't described
+//   by any of the record decls.
+// - (nil, other err): most likely IO failures.
+func (r *HierarchyReader) Read() (*idr.Node, error) {
+	if r.target != nil {
+		// This is just in case Release() isn't called by ingester.
+		idr.RemoveAndReleaseTree(r.target)
+		r.target = nil
+	}
+	for {
+		if r.target != nil {
+			return r.target, nil
+		}
+		more, err := r.r.MoreUnprocessedData()
+		if err != nil {
+			// r.r.MoreUnprocessedData() has encounter some real IO failures.
+			return nil, err
+		}
+		if !more {
+			// When the input is done, we still need to verified all the
+			// remaining decls' min occurs are satisfied. We can do so by
+			// simply keeping on moving to the next rec: we call recNext()
+			// once at a time - in case after the recNext() call, the reader
+			// yields another target node. We can safely do this (1 recNext()
+			// call at a time after we're told no more data) is because
+			// r.r.MoreUnprocessedData() should/will repeatedly return no more
+			// data after it declares so the first time.
+			if len(r.stack) <= 1 { // 1 is for the artificial root decl.
+				// If we don't have any more data, and our decl stack has been
+				// completed, then we're all done!!
+				return nil, io.EOF
+			}
+			err = r.recNext()
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		// Now at this point, we know we have more unprocessed data.
+		if len(r.stack) <= 1 {
+			// This means while all the rec decls' processings are done, we still
+			// have some unprocessed data.
+			return nil, ErrUnexpectedData{}
+		}
+		curRecEntry := r.stackTop()
+		node, err := r.readRec(curRecEntry.recDecl)
+		// Note given we have unprocessed data, r.readRec should never return
+		// io.EOF. So any error encountered, we directly bail out.
+		if err != nil {
+			return nil, err
+		}
+		// if no err returned from r.readRec, but node returned is nil, that means
+		// the current data isn't a match for the curRecEntry.recDecl. So the
+		// curRecEntry.recDecl instance is considered done.
+		if node == nil {
+			err = r.recNext() // move onto the decl's next instance.
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		curRecEntry.recNode = node
+		// the new idr node is a new instance of the current RecDecl thus when we add it to
+		// the IDR tree, we need to add it as a child of the current RecDecl's parent, thus
+		// adding it to stackTop(1), not (0).
+		idr.AddChild(r.stackTop(1).recNode, curRecEntry.recNode)
+		if len(curRecEntry.recDecl.ChildDecls()) > 0 {
+			r.growStack(stackEntry{recDecl: curRecEntry.recDecl.ChildDecls()[0]})
+			continue
+		}
+		r.recDone()
+	}
+}
+
+// Release deallocates/recycles the cached IDR node. If the passed in IDR node happens to be
+// the cached target node, we need to reset/clear the cached target node pointer.
+func (r *HierarchyReader) Release(n *idr.Node) {
+	if n == nil {
+		return
+	}
+	if r.target == n {
+		r.target = nil
+	}
+	idr.RemoveAndReleaseTree(n)
+}
+
+// readRec tries to read/match unprocessed data against the passed-in record decl.
+func (r *HierarchyReader) readRec(recDecl RecDecl) (*idr.Node, error) {
+	// If the decl is a solid non-group decl, then we will ask RecReader to match and create IDR.
+	// If the decl is a group, then we'll only ask RecReader to match but not creating IDR - instead
+	// we'll create an IDR node for the group decl here.
+	nonGroupDecl := recDecl
+	for nonGroupDecl.Group() && len(nonGroupDecl.ChildDecls()) > 0 {
+		nonGroupDecl = nonGroupDecl.ChildDecls()[0]
+	}
+	if nonGroupDecl.Group() {
+		// We must have a non-group solid record to perform the match; if not, it's a no
+		// match, thus returning nil for IDR and nil for error.
+		return nil, nil
+	}
+	// Now we have a solid record to perform match, let's call RecReader to do that.
+	// In case the recDecl is the solid non-group record itself, we can ask RecReader
+	// to perform the match and IDR node creation at the same time.
+	matched, node, err := r.r.ReadAndMatch(nonGroupDecl, !recDecl.Group())
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, nil
+	}
+	if recDecl.Group() {
+		return idr.CreateNode(idr.ElementNode, recDecl.DeclName()), nil
+	}
+	return node, nil
+}
+
+type stackEntry struct {
+	recDecl  RecDecl   // the current stack entry's record decl
+	recNode  *idr.Node // the current stack entry record's IDR node
+	curChild int       // which child record is the current record is processing.
+	occurred int       // how many instances the current record has encountered/processed.
+}
+
+const (
+	initialStackDepth = 10
+)
+
+// stackTop returns the pointer to the 'frame'-th stack entry from the top.
+// 'frame' is optional, if not specified, default 0 (aka the very top of
+// the stack) is assumed. Note caller NEVER owns the memory of the returned
+// entry, thus caller can use the pointer and its data values inside locally
+// but should never cache/save it somewhere for later usage.
+func (r *HierarchyReader) stackTop(frame ...int) *stackEntry {
+	nth := 0
+	if len(frame) == 1 {
+		nth = frame[0]
+	}
+	if nth < 0 || nth >= len(r.stack) {
+		panic(fmt.Sprintf("frame requested: %d, but stack length: %d", nth, len(r.stack)))
+	}
+	return &r.stack[len(r.stack)-nth-1]
+}
+
+// shrinkStack removes the top frame of the stack and returns the pointer to the NEW TOP
+// FRAME to caller. Note caller NEVER owns the memory of the returned entry, thus caller can
+// use the pointer and its data values inside locally but should never cache/save it somewhere
+// for later usage.
+func (r *HierarchyReader) shrinkStack() *stackEntry {
+	if len(r.stack) < 1 {
+		panic("stack length is empty")
+	}
+	r.stack = r.stack[:len(r.stack)-1]
+	if len(r.stack) < 1 {
+		return nil
+	}
+	return &r.stack[len(r.stack)-1]
+}
+
+// growStack adds a new stack entry to the top of the stack.
+func (r *HierarchyReader) growStack(e stackEntry) {
+	r.stack = append(r.stack, e)
+}
+
+// recDone wraps up the processing of an instance of current record (which includes the processing
+// of all the instances of its child records). recDone marks streaming target if necessary. If the
+// number of instance occurrences is over the current record's max limit, recDone calls recNext to
+// move to the next record in sequence; If the number of instances is still within max limit,
+// recDone does no more action so the current record will remain on top of the stack and potentially
+// process for more instances of this record. Note: recDone is potentially recursive:
+//   recDone -> recNext -> recDone -> ...
+func (r *HierarchyReader) recDone() {
+	cur := r.stackTop()
+	cur.curChild = 0
+	cur.occurred++
+	if cur.recDecl.Target() {
+		if r.target != nil {
+			panic("r.target != nil")
+		}
+		if cur.recNode == nil {
+			panic("cur.recNode == nil")
+		}
+		if r.targetXPathExpr == nil || idr.MatchAny(cur.recNode, r.targetXPathExpr) {
+			r.target = cur.recNode
+		} else {
+			idr.RemoveAndReleaseTree(cur.recNode)
+			cur.recNode = nil
+		}
+	}
+	if cur.occurred < cur.recDecl.MaxOccurs() {
+		return
+	}
+	// we're here because `cur.occurred >= cur.recDecl.MaxOccurs()`
+	// and the only path recNext() can fail is to have
+	// `cur.occurred < cur.recDecl.MinOccurs()`, which means
+	// the calling to recNext() from recDone() will never fail,
+	// assuming our file format specific validation makes sure min <= max.
+	_ = r.recNext()
+}
+
+// recNext is called when the top-of-stack (aka current) record is done its full processing and
+// needs to move to the next record. If the current record has a subsequent sibling, that sibling
+// will be the next record; If not, it indicates the current record's parent record is fully done
+// its processing, thus parent's recDone is called. Note: recNext is potentially recursive:
+//     recNext -> recDone -> recNext -> ...
+func (r *HierarchyReader) recNext() error {
+	cur := r.stackTop()
+	if cur.occurred < cur.recDecl.MinOccurs() {
+		return ErrFewerThanMinOccurs{
+			RecDecl:       cur.recDecl,
+			ActualOcccurs: cur.occurred,
+		}
+	}
+	if len(r.stack) <= 1 {
+		return nil
+	}
+	cur = r.shrinkStack()
+	if cur.curChild < len(cur.recDecl.ChildDecls())-1 {
+		cur.curChild++
+		r.growStack(stackEntry{recDecl: cur.recDecl.ChildDecls()[cur.curChild]})
+		return nil
+	}
+	r.recDone()
+	return nil
+}
+
+// ErrFewerThanMinOccurs indicates the input data doesn't have the required minimum
+// number of instances for a particular record decl.
+type ErrFewerThanMinOccurs struct {
+	RecDecl       RecDecl
+	ActualOcccurs int
+}
+
+// Error is to satisfy the error interface. Receivers of this error can/should consider
+// constructing their own file format specific error based on the payload of this error.
+func (e ErrFewerThanMinOccurs) Error() string {
+	return fmt.Sprintf("decl '%s' requires %d min occurs but only got %d",
+		e.RecDecl.DeclName(), e.RecDecl.MinOccurs(), e.ActualOcccurs)
+}
+
+// IsErrFewerThanMinOccurs tells whether a given err is of ErrFewerThanMinOccurs type.
+func IsErrFewerThanMinOccurs(err error) bool {
+	switch err.(type) {
+	case ErrFewerThanMinOccurs:
+		return true
+	default:
+		return false
+	}
+}
+
+// ErrUnexpectedData indicates there is unprocessed and unexpected data from the inpput data
+// stream that no record decl can match.
+type ErrUnexpectedData struct{}
+
+// IsErrUnexpectedData tells whether a given err is of ErrUnexpectedData type.
+func IsErrUnexpectedData(err error) bool {
+	switch err.(type) {
+	case ErrUnexpectedData:
+		return true
+	default:
+		return false
+	}
+}
+
+// Error is to satisfy the error interface. Receivers of this error can/should consider
+// constructing their own file format specific error based on the payload of this error.
+func (e ErrUnexpectedData) Error() string { return "unexpected data" }

--- a/extensions/omniv21/fileformat/flatfile/hierarchyReader_test.go
+++ b/extensions/omniv21/fileformat/flatfile/hierarchyReader_test.go
@@ -1,0 +1,521 @@
+package flatfile
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/antchfx/xpath"
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/jf-tech/go-corelib/jsons"
+	"github.com/jf-tech/go-corelib/maths"
+	"github.com/jf-tech/go-corelib/strs"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/idr"
+)
+
+type testRecReader struct {
+	moreReturns [][]interface{}
+	readReturns [][]interface{}
+}
+
+func (r *testRecReader) setMoreReturns(more bool, err error) *testRecReader {
+	r.moreReturns = append(r.moreReturns, []interface{}{more, err})
+	return r
+}
+
+func (r *testRecReader) MoreUnprocessedData() (more bool, err error) {
+	if len(r.moreReturns) <= 0 {
+		panic("no return values setup for test MoreUnprocessedData call")
+	}
+	more = r.moreReturns[0][0].(bool)
+	if r.moreReturns[0][1] != nil {
+		err = r.moreReturns[0][1].(error)
+	}
+	r.moreReturns = r.moreReturns[1:]
+	return
+}
+
+func (r *testRecReader) setReadReturns(matched bool, node *idr.Node, err error) *testRecReader {
+	r.readReturns = append(r.readReturns, []interface{}{matched, node, err})
+	return r
+}
+
+func (r *testRecReader) ReadAndMatch(RecDecl, bool) (matched bool, node *idr.Node, err error) {
+	if len(r.readReturns) <= 0 {
+		panic("no return values setup for test ReadAndMatch call")
+	}
+	matched = r.readReturns[0][0].(bool)
+	node = r.readReturns[0][1].(*idr.Node)
+	if r.readReturns[0][2] != nil {
+		err = r.readReturns[0][2].(error)
+	}
+	r.readReturns = r.readReturns[1:]
+	return
+}
+
+func TestRead(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		decls       []testDecl
+		recReader   *testRecReader
+		targetXPath *xpath.Expr
+		expReturns  [][]interface{}
+	}{
+		{
+			name:      "RecReader.MoreUnprocessedData failed first call",
+			recReader: (&testRecReader{}).setMoreReturns(false, errors.New("test error")),
+			expReturns: [][]interface{}{
+				{nil, errors.New("test error")},
+			},
+		},
+		{
+			name:      "no more data and decl stack already empty - we're done",
+			recReader: (&testRecReader{}).setMoreReturns(false, nil),
+			expReturns: [][]interface{}{
+				{nil, io.EOF},
+			},
+		},
+		{
+			name:      "no more data and last decl min occurs not satisfied",
+			decls:     []testDecl{{name: "test decl 1", min: 1}},
+			recReader: (&testRecReader{}).setMoreReturns(false, nil),
+			expReturns: [][]interface{}{
+				{nil, errors.New("decl 'test decl 1' requires 1 min occurs but only got 0")},
+			},
+		},
+		{
+			name:  "no more data and last decl min occurs satisfied - we're done",
+			decls: []testDecl{{name: "test decl 1", min: 0}},
+			recReader: (&testRecReader{}).
+				setMoreReturns(false, nil).
+				setMoreReturns(false, nil),
+			expReturns: [][]interface{}{
+				{nil, io.EOF},
+			},
+		},
+		{
+			name:      "more data but decl stack empty - unexpected data",
+			recReader: (&testRecReader{}).setMoreReturns(true, nil),
+			expReturns: [][]interface{}{
+				{nil, errors.New("unexpected data")},
+			},
+		},
+		{
+			name:  "more data but RecReader.ReadAndMatch failed",
+			decls: []testDecl{{name: "test decl 1", min: 0}},
+			recReader: (&testRecReader{}).
+				setMoreReturns(true, nil).
+				setReadReturns(false, nil, errors.New("test error")),
+			expReturns: [][]interface{}{
+				{nil, errors.New("test error")},
+			},
+		},
+		{
+			name:  "more data, but not match cur decl so it's done, but its min not satisified",
+			decls: []testDecl{{name: "test decl 1", min: 1}},
+			recReader: (&testRecReader{}).
+				setMoreReturns(true, nil).
+				setReadReturns(false, nil, nil),
+			expReturns: [][]interface{}{
+				{nil, errors.New("decl 'test decl 1' requires 1 min occurs but only got 0")},
+			},
+		},
+		{
+			name:  "more data, but not match cur decl so it's done, and its min satisified",
+			decls: []testDecl{{name: "test decl 1"}},
+			recReader: (&testRecReader{}).
+				setMoreReturns(true, nil).
+				setReadReturns(false, nil, nil).
+				setMoreReturns(false, nil),
+			expReturns: [][]interface{}{
+				{nil, io.EOF},
+			},
+		},
+		{
+			name:  "more data, match cur decl (which is target but has no children)",
+			decls: []testDecl{{name: "test decl 1", target: true}},
+			recReader: (&testRecReader{}).
+				setMoreReturns(true, nil).
+				setReadReturns(true, idr.CreateNode(idr.ElementNode, "test 1"), nil).
+				setMoreReturns(false, nil),
+			expReturns: [][]interface{}{
+				{idr.CreateNode(idr.ElementNode, "test 1"), nil},
+				{nil, io.EOF},
+			},
+		},
+		{
+			name:  "more data, match cur decl (which is target, and has children)",
+			decls: []testDecl{{name: "test decl 1", target: true, children: []testDecl{{}}}},
+			recReader: (&testRecReader{}).
+				setMoreReturns(true, nil).
+				setReadReturns(true, idr.CreateNode(idr.ElementNode, "test 1"), nil).
+				setMoreReturns(false, nil).
+				setMoreReturns(false, nil),
+			expReturns: [][]interface{}{
+				{idr.CreateNode(idr.ElementNode, "test 1"), nil},
+				{nil, io.EOF},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := NewHierarchyReader(toDeclSlice(test.decls), test.recReader, test.targetXPath)
+			for _, expRet := range test.expReturns {
+				n, err := r.Read()
+				if expRet[0] != nil {
+					expNode := expRet[0].(*idr.Node)
+					assert.NotNil(t, n)
+					assert.Equal(t, expNode.Type, n.Type)
+					assert.Equal(t, expNode.Data, n.Data)
+				} else {
+					assert.Nil(t, n)
+				}
+				if expRet[1] != nil {
+					assert.Error(t, err)
+					assert.Equal(t, expRet[1].(error).Error(), err.Error())
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}
+
+func TestRelease(t *testing.T) {
+	target := idr.CreateNode(idr.ElementNode, "test")
+	r := &HierarchyReader{target: target}
+	r.Release(nil)
+	assert.Equal(t, target, r.target)
+	r.Release(target)
+	assert.Nil(t, r.target)
+}
+
+func TestReadRec(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		reader  *testRecReader
+		decl    testDecl
+		expNode *idr.Node
+		expErr  string
+	}{
+		{
+			name:   "no non-group descendent decl",
+			reader: nil,
+			decl: testDecl{
+				group: true,
+				children: []testDecl{
+					{group: true},
+				},
+			},
+			expNode: nil,
+			expErr:  "",
+		},
+		{
+			name:   "RecReader.ReadAndMatch returns error",
+			reader: (&testRecReader{}).setReadReturns(false, nil, errors.New("test error")),
+			decl: testDecl{
+				group:    true,
+				children: []testDecl{{}},
+			},
+			expNode: nil,
+			expErr:  "test error",
+		},
+		{
+			name:    "RecReader.ReadAndMatch returns not matched",
+			reader:  (&testRecReader{}).setReadReturns(false, nil, nil),
+			decl:    testDecl{},
+			expNode: nil,
+			expErr:  "",
+		},
+		{
+			name:   "RecReader.ReadAndMatch returns group node",
+			reader: (&testRecReader{}).setReadReturns(true, nil, nil),
+			decl: testDecl{
+				name:     "group decl 1",
+				group:    true,
+				children: []testDecl{{}},
+			},
+			expNode: idr.CreateNode(idr.ElementNode, "group decl 1"),
+			expErr:  "",
+		},
+		{
+			name: "RecReader.ReadAndMatch returns non-group node",
+			reader: (&testRecReader{}).setReadReturns(
+				true, idr.CreateNode(idr.ElementNode, "non group decl 1"), nil),
+			decl: testDecl{
+				name: "non group decl 1",
+			},
+			expNode: idr.CreateNode(idr.ElementNode, "non group decl 1"),
+			expErr:  "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := HierarchyReader{r: test.reader}
+			n, err := r.readRec(test.decl)
+			if test.expNode != nil {
+				assert.NotNil(t, n)
+				assert.Equal(t, test.expNode.Type, n.Type)
+				assert.Equal(t, test.expNode.Data, n.Data)
+			} else {
+				assert.Nil(t, n)
+			}
+			if strs.IsStrNonBlank(test.expErr) {
+				assert.Error(t, err)
+				assert.Equal(t, test.expErr, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStack(t *testing.T) {
+	r := HierarchyReader{
+		stack: make([]stackEntry, 0, initialStackDepth),
+	}
+	// try to access top of stack while there is nothing in it => panic.
+	assert.PanicsWithValue(t,
+		"frame requested: 0, but stack length: 0",
+		func() {
+			r.stackTop()
+		})
+	// try to shrink empty stack => panic.
+	assert.PanicsWithValue(t,
+		"stack length is empty",
+		func() {
+			r.shrinkStack()
+		})
+	newEntry1 := stackEntry{
+		recDecl:  testDecl{},
+		recNode:  idr.CreateNode(idr.TextNode, "test"),
+		curChild: 5,
+		occurred: 10,
+	}
+	r.growStack(newEntry1)
+	assert.Equal(t, 1, len(r.stack))
+	assert.Equal(t, newEntry1, *r.stackTop())
+	newEntry2 := stackEntry{
+		recDecl:  testDecl{},
+		recNode:  idr.CreateNode(idr.TextNode, "test 2"),
+		curChild: 10,
+		occurred: 20,
+	}
+	r.growStack(newEntry2)
+	assert.Equal(t, 2, len(r.stack))
+	assert.Equal(t, newEntry2, *r.stackTop())
+	// try to access a frame that doesn't exist => panic.
+	assert.PanicsWithValue(t,
+		"frame requested: 2, but stack length: 2",
+		func() {
+			r.stackTop(2)
+		})
+	assert.Equal(t, newEntry1, *r.shrinkStack())
+	assert.Nil(t, r.shrinkStack())
+}
+
+// for tests to create snapshots of stack entries.
+func (s stackEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		RecDecl  string
+		RecNode  *string
+		CurChild int
+		Occurred int
+	}{
+		RecDecl: s.recDecl.DeclName(),
+		RecNode: func() *string {
+			if s.recNode == nil {
+				return nil
+			}
+			return strs.StrPtr(s.recNode.Data)
+		}(),
+		CurChild: s.curChild,
+		Occurred: s.occurred,
+	})
+}
+
+func TestRecDoneRecNext(t *testing.T) {
+	// the following indicates the test RecDecl tree structure. The numbers in () are min/max.
+	//  root (1/1)
+	//    A (1/unbounded)   <-- target
+	//      B (0/1)
+	//      C (1/2)
+	//    D (0/1)
+	recDeclB := testDecl{name: "B", min: 0, max: 1}
+	recDeclC := testDecl{name: "C", min: 1, max: 2}
+	recDeclA := testDecl{name: "A", min: 1, max: maths.MaxIntValue, target: true,
+		children: []testDecl{recDeclB, recDeclC}}
+	recDeclD := testDecl{name: "D", min: 0, max: 1}
+	recDeclRoot := testDecl{name: rootName, min: 1, max: 1, group: true,
+		children: []testDecl{recDeclA, recDeclD}}
+
+	for _, test := range []struct {
+		name        string
+		stack       []stackEntry
+		target      *idr.Node
+		targetXPath *string
+		callRecDone bool
+		panicStr    string
+		err         string
+	}{
+		{
+			name: "root-A-B, B recDone, moves to C, no target",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 0, 0},
+				{recDeclA, idr.CreateNode(idr.ElementNode, "A"), 0, 0},
+				{recDeclB, idr.CreateNode(idr.ElementNode, "B"), 0, 0},
+			},
+			target:      nil,
+			targetXPath: nil,
+			callRecDone: true,
+			panicStr:    "",
+			err:         "",
+		},
+		{
+			name: "root-A-C, C recDone, stay, no target",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 0, 0},
+				{recDeclA, idr.CreateNode(idr.ElementNode, "A"), 1, 0},
+				{recDeclC, idr.CreateNode(idr.ElementNode, "C"), 0, 0},
+			},
+			target:      nil,
+			targetXPath: nil,
+			callRecDone: true,
+			panicStr:    "",
+			err:         "",
+		},
+		{
+			name: "root-A-C, C recDone, C over max, A becomes target",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 0, 0},
+				{recDeclA, idr.CreateNode(idr.ElementNode, "A"), 1, 0},
+				{recDeclC, idr.CreateNode(idr.ElementNode, "C"), 0, 1},
+			},
+			target:      nil,
+			targetXPath: nil,
+			callRecDone: true,
+			panicStr:    "",
+			err:         "",
+		},
+		{
+			name: "root-D, D recDone",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 1, 0},
+				{recDeclD, idr.CreateNode(idr.ElementNode, "D"), 0, 0},
+			},
+			target:      nil,
+			targetXPath: nil,
+			callRecDone: true,
+			panicStr:    "",
+			err:         "",
+		},
+		{
+			name: "root-A-C, C.occurred = 1, C recNext",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 0, 0},
+				{recDeclA, idr.CreateNode(idr.ElementNode, "A"), 1, 0},
+				{recDeclC, idr.CreateNode(idr.ElementNode, "C"), 0, 0},
+			},
+			target:      nil,
+			targetXPath: nil,
+			callRecDone: false,
+			panicStr:    "",
+			err:         `decl 'C' requires 1 min occurs but only got 0`,
+		},
+		{
+			name: "root-A-C, C recDone, C over max, A becomes target, but r.target not nil",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 0, 0},
+				{recDeclA, idr.CreateNode(idr.ElementNode, "A"), 1, 0},
+				{recDeclC, idr.CreateNode(idr.ElementNode, "C"), 0, 1},
+			},
+			target:      idr.CreateNode(idr.ElementNode, ""),
+			targetXPath: nil,
+			callRecDone: true,
+			panicStr:    `r.target != nil`,
+			err:         "",
+		},
+		{
+			name: "root-A-C, C recDone, C over max, A becomes target, but A.recNode is nil",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 0, 0},
+				{recDeclA, nil, 1, 0},
+				{recDeclC, idr.CreateNode(idr.ElementNode, "C"), 0, 1},
+			},
+			target:      nil,
+			targetXPath: nil,
+			callRecDone: true,
+			panicStr:    `cur.recNode == nil`,
+			err:         "",
+		},
+		{
+			name: "root-A-C, C recDone, C over max, A becomes target, but target xpath no match",
+			stack: []stackEntry{
+				{recDeclRoot, idr.CreateNode(idr.DocumentNode, rootName), 0, 0},
+				{recDeclA, idr.CreateNode(idr.ElementNode, "A"), 1, 0},
+				{recDeclC, idr.CreateNode(idr.ElementNode, "C"), 0, 1},
+			},
+			target:      nil,
+			targetXPath: strs.StrPtr("no_match"),
+			callRecDone: true,
+			panicStr:    "",
+			err:         "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := &HierarchyReader{
+				stack:  test.stack,
+				target: test.target,
+			}
+			if test.targetXPath != nil {
+				r.targetXPathExpr = xpath.MustCompile(*test.targetXPath)
+			}
+			var err error
+			testCall := func() {
+				if test.callRecDone {
+					r.recDone()
+				} else {
+					err = r.recNext()
+				}
+			}
+			if test.panicStr != "" {
+				assert.PanicsWithValue(t, test.panicStr, testCall)
+				return
+			}
+			testCall()
+			if test.err != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+				return
+			}
+			assert.NoError(t, err)
+			cupaloy.SnapshotT(t, jsons.BPM(
+				struct {
+					Stack  []stackEntry
+					Target *string
+				}{
+					Stack: r.stack,
+					Target: func() *string {
+						if r.target == nil {
+							return nil
+						}
+						return strs.StrPtr(r.target.Data)
+					}(),
+				}))
+		})
+	}
+}
+
+func TestIsErrFewerThanMinOccurs(t *testing.T) {
+	assert.True(t, IsErrFewerThanMinOccurs(ErrFewerThanMinOccurs{}))
+	assert.Equal(t, "decl 'd' requires 5 min occurs but only got 0",
+		ErrFewerThanMinOccurs{RecDecl: testDecl{name: "d", min: 5}}.Error())
+	assert.False(t, IsErrFewerThanMinOccurs(errors.New("test")))
+}
+
+func TestIsErrUnexpectedData(t *testing.T) {
+	assert.True(t, IsErrUnexpectedData(ErrUnexpectedData{}))
+	assert.Equal(t, "unexpected data", ErrUnexpectedData{}.Error())
+	assert.False(t, IsErrUnexpectedData(errors.New("test")))
+}


### PR DESCRIPTION
And more thorough unit level tests (compared with more end-to-end-ish tests in edi.reader)

For comparison, edi.reader:

https://github.com/jf-tech/omniparser/blob/927d69a1960aa8268a4e5eb828c605abd013f36c/extensions/omniv21/fileformat/edi/reader.go