### PR TITLE
Adding flatfile.fixedlength validation routines.

### DIFF
--- a/extensions/omniv21/fileformat/flatfile/fixedlength/validate.go
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/validate.go
@@ -1,0 +1,88 @@
+package fixedlength
+
+import (
+	"fmt"
+
+	"github.com/jf-tech/go-corelib/caches"
+	"github.com/jf-tech/go-corelib/strs"
+)
+
+type validateCtx struct {
+	seenTarget bool
+}
+
+func (ctx *validateCtx) validateFileDecl(fileDecl *FileDecl) error {
+	for _, envelopeDecl := range fileDecl.Envelopes {
+		if err := ctx.validateEnvelopeDecl(envelopeDecl.Name, envelopeDecl); err != nil {
+			return err
+		}
+	}
+	if !ctx.seenTarget && len(fileDecl.Envelopes) > 0 {
+		// for easy of use and convenience, if no is_target=true envelope is specified, then
+		// the first one will be automatically designated as target envelope.
+		fileDecl.Envelopes[0].IsTarget = true
+	}
+	return nil
+}
+
+func (ctx *validateCtx) validateEnvelopeDecl(fqdn string, envelopeDecl *EnvelopeDecl) (err error) {
+	envelopeDecl.fqdn = fqdn
+	if envelopeDecl.Header != nil {
+		if envelopeDecl.headerRegexp, err = caches.GetRegex(*envelopeDecl.Header); err != nil {
+			return fmt.Errorf(
+				"envelope/envelope_group '%s' has an invalid 'header' regexp '%s': %s",
+				fqdn, *envelopeDecl.Header, err.Error())
+		}
+	}
+	if envelopeDecl.Footer != nil {
+		if envelopeDecl.footerRegexp, err = caches.GetRegex(*envelopeDecl.Footer); err != nil {
+			return fmt.Errorf(
+				"envelope/envelope_group '%s' has an invalid 'footer' regexp '%s': %s",
+				fqdn, *envelopeDecl.Footer, err.Error())
+		}
+	}
+	if envelopeDecl.Group() {
+		if len(envelopeDecl.Columns) > 0 {
+			return fmt.Errorf("envelope_group '%s' must not have any columns", fqdn)
+		}
+		if len(envelopeDecl.Children) <= 0 {
+			return fmt.Errorf(
+				"envelope_group '%s' must have at least one child envelope/envelope_group", fqdn)
+		}
+	}
+	if envelopeDecl.Target() {
+		if ctx.seenTarget {
+			return fmt.Errorf(
+				"a second envelope/envelope_group ('%s') with 'is_target' = true is not allowed",
+				fqdn)
+		}
+		ctx.seenTarget = true
+	}
+	if envelopeDecl.MinOccurs() > envelopeDecl.MaxOccurs() {
+		return fmt.Errorf("envelope/envelope_group '%s' has 'min' value %d > 'max' value %d",
+			fqdn, envelopeDecl.MinOccurs(), envelopeDecl.MaxOccurs())
+	}
+	for _, colDecl := range envelopeDecl.Columns {
+		if err = ctx.validateColumnDecl(fqdn, colDecl); err != nil {
+			return err
+		}
+	}
+	for _, c := range envelopeDecl.Children {
+		if err = ctx.validateEnvelopeDecl(strs.BuildFQDN2("/", fqdn, c.Name), c); err != nil {
+			return err
+		}
+	}
+	envelopeDecl.childRecDecls = toFlatFileRecDecls(envelopeDecl.Children)
+	return nil
+}
+
+func (ctx *validateCtx) validateColumnDecl(fqdn string, colDecl *ColumnDecl) (err error) {
+	if colDecl.LinePattern != nil {
+		if colDecl.linePatternRegexp, err = caches.GetRegex(*colDecl.LinePattern); err != nil {
+			return fmt.Errorf(
+				"envelope '%s' column '%s' has an invalid 'line_pattern' regexp '%s': %s",
+				fqdn, colDecl.Name, *colDecl.LinePattern, err.Error())
+		}
+	}
+	return nil
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/validate_test.go
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/validate_test.go
@@ -1,0 +1,141 @@
+package fixedlength
+
+import (
+	"testing"
+
+	"github.com/jf-tech/go-corelib/strs"
+	"github.com/jf-tech/go-corelib/testlib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateFileDecl_AutoTargetFirstEnvelope(t *testing.T) {
+	decl := &FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{Name: "A"},
+		},
+	}
+	assert.False(t, decl.Envelopes[0].Target())
+	err := (&validateCtx{}).validateFileDecl(decl)
+	assert.NoError(t, err)
+	assert.True(t, decl.Envelopes[0].Target())
+}
+
+func TestValidateFileDecl_InvalidHeaderRegexp(t *testing.T) {
+	err := (&validateCtx{}).validateFileDecl(&FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{Name: "A", Header: strs.StrPtr("[invalid")},
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t,
+		"envelope/envelope_group 'A' has an invalid 'header' regexp '[invalid': error parsing regexp: missing closing ]: `[invalid`",
+		err.Error())
+}
+
+func TestValidateFileDecl_InvalidFooterRegexp(t *testing.T) {
+	err := (&validateCtx{}).validateFileDecl(&FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{Name: "A", Footer: strs.StrPtr("[invalid")},
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t,
+		"envelope/envelope_group 'A' has an invalid 'footer' regexp '[invalid': error parsing regexp: missing closing ]: `[invalid`",
+		err.Error())
+}
+
+func TestValidateFileDecl_GroupHasColumns(t *testing.T) {
+	err := (&validateCtx{}).validateFileDecl(&FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{
+				Name:     "A",
+				Type:     strs.StrPtr(typeGroup),
+				Columns:  []*ColumnDecl{{}},
+				Children: []*EnvelopeDecl{{}},
+			},
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, `envelope_group 'A' must not have any columns`, err.Error())
+}
+
+func TestValidateFileDecl_GroupHasNoChildren(t *testing.T) {
+	err := (&validateCtx{}).validateFileDecl(&FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{Name: "A", Type: strs.StrPtr(typeGroup), IsTarget: true},
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t,
+		`envelope_group 'A' must have at least one child envelope/envelope_group`, err.Error())
+}
+
+func TestValidateFileDecl_TwoIsTarget(t *testing.T) {
+	err := (&validateCtx{}).validateFileDecl(&FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{Name: "A", IsTarget: true},
+			{Name: "B", Type: strs.StrPtr(typeGroup), Children: []*EnvelopeDecl{
+				{Name: "C", IsTarget: true},
+			}},
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t,
+		`a second envelope/envelope_group ('B/C') with 'is_target' = true is not allowed`,
+		err.Error())
+}
+
+func TestValidateFileDecl_MinGreaterThanMax(t *testing.T) {
+	err := (&validateCtx{}).validateFileDecl(&FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{Name: "A", Children: []*EnvelopeDecl{
+				{Name: "B", Min: testlib.IntPtr(2), Max: testlib.IntPtr(1)}}},
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, `envelope/envelope_group 'A/B' has 'min' value 2 > 'max' value 1`, err.Error())
+}
+
+func TestValidateFileDecl_InvalidColumnLinePattern(t *testing.T) {
+	err := (&validateCtx{}).validateFileDecl(&FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{Name: "A", Columns: []*ColumnDecl{
+				{Name: "c", LinePattern: strs.StrPtr("[invalid")}}},
+		},
+	})
+	assert.Error(t, err)
+	assert.Equal(t,
+		"envelope 'A' column 'c' has an invalid 'line_pattern' regexp '[invalid': error parsing regexp: missing closing ]: `[invalid`",
+		err.Error())
+}
+
+func TestValidateFileDecl_Success(t *testing.T) {
+	col1 := &ColumnDecl{Name: "c1"}
+	col2 := &ColumnDecl{Name: "c2"}
+	col3 := &ColumnDecl{Name: "c3", LinePattern: strs.StrPtr("^C$")}
+	fd := &FileDecl{
+		Envelopes: []*EnvelopeDecl{
+			{
+				Name:   "A",
+				Header: strs.StrPtr("^A_BEGIN$"),
+				Footer: strs.StrPtr("^A_END$"),
+				Children: []*EnvelopeDecl{
+					{
+						Name: "B", IsTarget: true,
+						Columns: []*ColumnDecl{col1, col2, col3},
+					},
+				},
+			},
+		},
+	}
+	err := (&validateCtx{}).validateFileDecl(fd)
+	assert.NoError(t, err)
+	assert.Equal(t, "A", fd.Envelopes[0].fqdn)
+	assert.True(t, fd.Envelopes[0].matchHeader([]byte("A_BEGIN")))
+	assert.True(t, fd.Envelopes[0].matchFooter([]byte("A_END")))
+	assert.Equal(t, 1, len(fd.Envelopes[0].childRecDecls))
+	assert.Same(t, fd.Envelopes[0].Children[0], fd.Envelopes[0].childRecDecls[0].(*EnvelopeDecl))
+	assert.Equal(t, "A/B", fd.Envelopes[0].Children[0].fqdn)
+	assert.Equal(t, []*ColumnDecl{col1, col2, col3}, fd.Envelopes[0].Children[0].Columns)
+	assert.True(t, fd.Envelopes[0].Children[0].Columns[2].lineMatch([]byte("C")))
+}

--- a/extensions/omniv21/validation/fixedlength2FileDeclaration.go
+++ b/extensions/omniv21/validation/fixedlength2FileDeclaration.go
@@ -55,7 +55,7 @@ const (
                     }
                 }
             },
-            "required": [],
+            "required": [], "$comment": "yes, 'name' is actually optional",
             "additionalProperties": false
         },
         "envelope_header_footer_based": {
@@ -84,7 +84,7 @@ const (
                     }
                 }
             },
-            "required": [ "header" ],
+            "required": [ "header" ], "$comment": "yes, 'name' is actually optional",
             "additionalProperties": false
         },
         "column_type": {

--- a/extensions/omniv21/validation/fixedlength2FileDeclaration.json
+++ b/extensions/omniv21/validation/fixedlength2FileDeclaration.json
@@ -48,7 +48,7 @@
                     }
                 }
             },
-            "required": [],
+            "required": [], "$comment": "yes, 'name' is actually optional",
             "additionalProperties": false
         },
         "envelope_header_footer_based": {
@@ -77,7 +77,7 @@
                     }
                 }
             },
-            "required": [ "header" ],
+            "required": [ "header" ], "$comment": "yes, 'name' is actually optional",
             "additionalProperties": false
         },
         "column_type": {


### PR DESCRIPTION
Most of the heavy-lifting validation is done through JSON schema, but there are some validations have to be done in code, namely those cross property validations (such as min>max, etc) as well as some decl preparation during the validation phase, such as initializing/compiling regexp.