### PR TITLE
Adding flatfile.reader and format - thus completing the new 'fixed-length2' format handler with nested structure support.

### DIFF
--- a/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestLinesToNode-line_matches
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestLinesToNode-line_matches
@@ -1,0 +1,58 @@
+{
+	"Children": [
+		{
+			"Children": [
+				{
+					"Children": null,
+					"Data": "world",
+					"FirstChild": null,
+					"FormatSpecific": null,
+					"LastChild": null,
+					"NextSibling": null,
+					"Parent": "(ElementNode W)",
+					"PrevSibling": null,
+					"Type": "TextNode"
+				}
+			],
+			"Data": "W",
+			"FirstChild": "(TextNode 'world')",
+			"FormatSpecific": null,
+			"LastChild": "(TextNode 'world')",
+			"NextSibling": "(ElementNode C)",
+			"Parent": "(ElementNode test-envelope)",
+			"PrevSibling": null,
+			"Type": "ElementNode"
+		},
+		{
+			"Children": [
+				{
+					"Children": null,
+					"Data": "c",
+					"FirstChild": null,
+					"FormatSpecific": null,
+					"LastChild": null,
+					"NextSibling": null,
+					"Parent": "(ElementNode C)",
+					"PrevSibling": null,
+					"Type": "TextNode"
+				}
+			],
+			"Data": "C",
+			"FirstChild": "(TextNode 'c')",
+			"FormatSpecific": null,
+			"LastChild": "(TextNode 'c')",
+			"NextSibling": null,
+			"Parent": "(ElementNode test-envelope)",
+			"PrevSibling": "(ElementNode W)",
+			"Type": "ElementNode"
+		}
+	],
+	"Data": "test-envelope",
+	"FirstChild": "(ElementNode W)",
+	"FormatSpecific": null,
+	"LastChild": "(ElementNode C)",
+	"NextSibling": null,
+	"Parent": null,
+	"PrevSibling": null,
+	"Type": "ElementNode"
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestRead-success
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestRead-success
@@ -1,0 +1,198 @@
+{
+	"Children": [
+		{
+			"Children": [
+				{
+					"Children": [
+						{
+							"Children": null,
+							"Data": "2",
+							"FirstChild": null,
+							"FormatSpecific": null,
+							"LastChild": null,
+							"NextSibling": null,
+							"Parent": "(ElementNode c2)",
+							"PrevSibling": null,
+							"Type": "TextNode"
+						}
+					],
+					"Data": "c2",
+					"FirstChild": "(TextNode '2')",
+					"FormatSpecific": null,
+					"LastChild": "(TextNode '2')",
+					"NextSibling": null,
+					"Parent": "(ElementNode e2)",
+					"PrevSibling": null,
+					"Type": "ElementNode"
+				}
+			],
+			"Data": "e2",
+			"FirstChild": "(ElementNode c2)",
+			"FormatSpecific": null,
+			"LastChild": "(ElementNode c2)",
+			"NextSibling": "(ElementNode e3)",
+			"Parent": "(ElementNode e1)",
+			"PrevSibling": null,
+			"Type": "ElementNode"
+		},
+		{
+			"Children": [
+				{
+					"Children": [
+						{
+							"Children": null,
+							"Data": "1",
+							"FirstChild": null,
+							"FormatSpecific": null,
+							"LastChild": null,
+							"NextSibling": null,
+							"Parent": "(ElementNode c31)",
+							"PrevSibling": null,
+							"Type": "TextNode"
+						}
+					],
+					"Data": "c31",
+					"FirstChild": "(TextNode '1')",
+					"FormatSpecific": null,
+					"LastChild": "(TextNode '1')",
+					"NextSibling": "(ElementNode c32)",
+					"Parent": "(ElementNode e3)",
+					"PrevSibling": null,
+					"Type": "ElementNode"
+				},
+				{
+					"Children": [
+						{
+							"Children": null,
+							"Data": "2",
+							"FirstChild": null,
+							"FormatSpecific": null,
+							"LastChild": null,
+							"NextSibling": null,
+							"Parent": "(ElementNode c32)",
+							"PrevSibling": null,
+							"Type": "TextNode"
+						}
+					],
+					"Data": "c32",
+					"FirstChild": "(TextNode '2')",
+					"FormatSpecific": null,
+					"LastChild": "(TextNode '2')",
+					"NextSibling": null,
+					"Parent": "(ElementNode e3)",
+					"PrevSibling": "(ElementNode c31)",
+					"Type": "ElementNode"
+				}
+			],
+			"Data": "e3",
+			"FirstChild": "(ElementNode c31)",
+			"FormatSpecific": null,
+			"LastChild": "(ElementNode c32)",
+			"NextSibling": "(ElementNode e3)",
+			"Parent": "(ElementNode e1)",
+			"PrevSibling": "(ElementNode e2)",
+			"Type": "ElementNode"
+		},
+		{
+			"Children": [
+				{
+					"Children": [
+						{
+							"Children": null,
+							"Data": "3",
+							"FirstChild": null,
+							"FormatSpecific": null,
+							"LastChild": null,
+							"NextSibling": null,
+							"Parent": "(ElementNode c31)",
+							"PrevSibling": null,
+							"Type": "TextNode"
+						}
+					],
+					"Data": "c31",
+					"FirstChild": "(TextNode '3')",
+					"FormatSpecific": null,
+					"LastChild": "(TextNode '3')",
+					"NextSibling": "(ElementNode c32)",
+					"Parent": "(ElementNode e3)",
+					"PrevSibling": null,
+					"Type": "ElementNode"
+				},
+				{
+					"Children": [
+						{
+							"Children": null,
+							"Data": "4",
+							"FirstChild": null,
+							"FormatSpecific": null,
+							"LastChild": null,
+							"NextSibling": null,
+							"Parent": "(ElementNode c32)",
+							"PrevSibling": null,
+							"Type": "TextNode"
+						}
+					],
+					"Data": "c32",
+					"FirstChild": "(TextNode '4')",
+					"FormatSpecific": null,
+					"LastChild": "(TextNode '4')",
+					"NextSibling": null,
+					"Parent": "(ElementNode e3)",
+					"PrevSibling": "(ElementNode c31)",
+					"Type": "ElementNode"
+				}
+			],
+			"Data": "e3",
+			"FirstChild": "(ElementNode c31)",
+			"FormatSpecific": null,
+			"LastChild": "(ElementNode c32)",
+			"NextSibling": "(ElementNode e4)",
+			"Parent": "(ElementNode e1)",
+			"PrevSibling": "(ElementNode e3)",
+			"Type": "ElementNode"
+		},
+		{
+			"Children": [
+				{
+					"Children": [
+						{
+							"Children": null,
+							"Data": "4",
+							"FirstChild": null,
+							"FormatSpecific": null,
+							"LastChild": null,
+							"NextSibling": null,
+							"Parent": "(ElementNode c4)",
+							"PrevSibling": null,
+							"Type": "TextNode"
+						}
+					],
+					"Data": "c4",
+					"FirstChild": "(TextNode '4')",
+					"FormatSpecific": null,
+					"LastChild": "(TextNode '4')",
+					"NextSibling": null,
+					"Parent": "(ElementNode e4)",
+					"PrevSibling": null,
+					"Type": "ElementNode"
+				}
+			],
+			"Data": "e4",
+			"FirstChild": "(ElementNode c4)",
+			"FormatSpecific": null,
+			"LastChild": "(ElementNode c4)",
+			"NextSibling": null,
+			"Parent": "(ElementNode e1)",
+			"PrevSibling": "(ElementNode e3)",
+			"Type": "ElementNode"
+		}
+	],
+	"Data": "e1",
+	"FirstChild": "(ElementNode e2)",
+	"FormatSpecific": null,
+	"LastChild": "(ElementNode e4)",
+	"NextSibling": null,
+	"Parent": "(DocumentNode)",
+	"PrevSibling": null,
+	"Type": "ElementNode"
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestReadAndMatchHeaderFooterBasedEnvelope-empty_buf;_single_line_header-footer_match
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestReadAndMatchHeaderFooterBasedEnvelope-empty_buf;_single_line_header-footer_match
@@ -1,0 +1,35 @@
+{
+	"Children": [
+		{
+			"Children": [
+				{
+					"Children": null,
+					"Data": "1",
+					"FirstChild": null,
+					"FormatSpecific": null,
+					"LastChild": null,
+					"NextSibling": null,
+					"Parent": "(ElementNode C)",
+					"PrevSibling": null,
+					"Type": "TextNode"
+				}
+			],
+			"Data": "C",
+			"FirstChild": "(TextNode '1')",
+			"FormatSpecific": null,
+			"LastChild": "(TextNode '1')",
+			"NextSibling": null,
+			"Parent": "(ElementNode E)",
+			"PrevSibling": null,
+			"Type": "ElementNode"
+		}
+	],
+	"Data": "E",
+	"FirstChild": "(ElementNode C)",
+	"FormatSpecific": null,
+	"LastChild": "(ElementNode C)",
+	"NextSibling": null,
+	"Parent": null,
+	"PrevSibling": null,
+	"Type": "ElementNode"
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestReadAndMatchRowsBasedEnvelope-non-empty_buf;_no_read;_match;_create_IDR
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestReadAndMatchRowsBasedEnvelope-non-empty_buf;_no_read;_match;_create_IDR
@@ -1,0 +1,58 @@
+{
+	"Children": [
+		{
+			"Children": [
+				{
+					"Children": null,
+					"Data": "1",
+					"FirstChild": null,
+					"FormatSpecific": null,
+					"LastChild": null,
+					"NextSibling": null,
+					"Parent": "(ElementNode C1)",
+					"PrevSibling": null,
+					"Type": "TextNode"
+				}
+			],
+			"Data": "C1",
+			"FirstChild": "(TextNode '1')",
+			"FormatSpecific": null,
+			"LastChild": "(TextNode '1')",
+			"NextSibling": "(ElementNode C2)",
+			"Parent": "(ElementNode E)",
+			"PrevSibling": null,
+			"Type": "ElementNode"
+		},
+		{
+			"Children": [
+				{
+					"Children": null,
+					"Data": "2",
+					"FirstChild": null,
+					"FormatSpecific": null,
+					"LastChild": null,
+					"NextSibling": null,
+					"Parent": "(ElementNode C2)",
+					"PrevSibling": null,
+					"Type": "TextNode"
+				}
+			],
+			"Data": "C2",
+			"FirstChild": "(TextNode '2')",
+			"FormatSpecific": null,
+			"LastChild": "(TextNode '2')",
+			"NextSibling": null,
+			"Parent": "(ElementNode E)",
+			"PrevSibling": "(ElementNode C1)",
+			"Type": "ElementNode"
+		}
+	],
+	"Data": "E",
+	"FirstChild": "(ElementNode C1)",
+	"FormatSpecific": null,
+	"LastChild": "(ElementNode C2)",
+	"NextSibling": null,
+	"Parent": null,
+	"PrevSibling": null,
+	"Type": "ElementNode"
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestValidateSchema-success
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/.snapshots/TestValidateSchema-success
@@ -1,0 +1,39 @@
+{
+	"file_declaration": {
+		"envelopes": [
+			{
+				"name": "e1",
+				"type": "envelope_group",
+				"is_target": true,
+				"min": 1,
+				"max": 1,
+				"child_envelopes": [
+					{
+						"name": "e2",
+						"max": 5,
+						"columns": [
+							{
+								"name": "c1",
+								"start_pos": 1,
+								"length": 3
+							}
+						]
+					},
+					{
+						"name": "e2",
+						"header": "^ABC$",
+						"columns": [
+							{
+								"name": "c2",
+								"start_pos": 2,
+								"length": 5,
+								"line_pattern": "^H00"
+							}
+						]
+					}
+				]
+			}
+		]
+	},
+	"XPath": ".[c1 != 'skip']"
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/format.go
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/format.go
@@ -1,0 +1,95 @@
+package fixedlength
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/antchfx/xpath"
+	"github.com/jf-tech/go-corelib/caches"
+	"github.com/jf-tech/go-corelib/strs"
+
+	"github.com/jf-tech/omniparser/errs"
+	"github.com/jf-tech/omniparser/extensions/omniv21/fileformat"
+	"github.com/jf-tech/omniparser/extensions/omniv21/transform"
+	v21validation "github.com/jf-tech/omniparser/extensions/omniv21/validation"
+	"github.com/jf-tech/omniparser/validation"
+)
+
+const (
+	fileFormatFixedLength = "fixedlength2"
+)
+
+type fixedLengthFormat struct {
+	schemaName string
+}
+
+// NewFixedLengthFileFormat creates a FileFormat for 'fixedlength2'.
+func NewFixedLengthFileFormat(schemaName string) fileformat.FileFormat {
+	return &fixedLengthFormat{schemaName: schemaName}
+}
+
+type fixedLengthFormatRuntime struct {
+	Decl  *FileDecl `json:"file_declaration"`
+	XPath string
+}
+
+func (f *fixedLengthFormat) ValidateSchema(
+	format string, schemaContent []byte, finalOutputDecl *transform.Decl) (interface{}, error) {
+	if format != fileFormatFixedLength {
+		return nil, errs.ErrSchemaNotSupported
+	}
+	err := validation.SchemaValidate(
+		f.schemaName, schemaContent, v21validation.JSONSchemaFixedLength2FileDeclaration)
+	if err != nil {
+		// err is already context formatted.
+		return nil, err
+	}
+	var runtime fixedLengthFormatRuntime
+	_ = json.Unmarshal(schemaContent, &runtime) // JSON schema validation earlier guarantees Unmarshal success.
+	err = f.validateFileDecl(runtime.Decl)
+	if err != nil {
+		// err is already context formatted.
+		return nil, err
+	}
+	if finalOutputDecl == nil {
+		return nil, f.FmtErr("'FINAL_OUTPUT' is missing")
+	}
+	runtime.XPath = strings.TrimSpace(strs.StrPtrOrElse(finalOutputDecl.XPath, ""))
+	if runtime.XPath != "" {
+		_, err := caches.GetXPathExpr(runtime.XPath)
+		if err != nil {
+			return nil, f.FmtErr("'FINAL_OUTPUT.xpath' (value: '%s') is invalid, err: %s",
+				runtime.XPath, err.Error())
+		}
+	}
+	return &runtime, nil
+}
+
+func (f *fixedLengthFormat) validateFileDecl(decl *FileDecl) error {
+	err := (&validateCtx{}).validateFileDecl(decl)
+	if err != nil {
+		return f.FmtErr(err.Error())
+	}
+	return err
+}
+
+func (f *fixedLengthFormat) CreateFormatReader(
+	name string, r io.Reader, runtime interface{}) (fileformat.FormatReader, error) {
+	rt := runtime.(*fixedLengthFormatRuntime)
+	targetXPathExpr, err := func() (*xpath.Expr, error) {
+		if rt.XPath == "" || rt.XPath == "." {
+			return nil, nil
+		}
+		return caches.GetXPathExpr(rt.XPath)
+	}()
+	if err != nil {
+		return nil, f.FmtErr("xpath '%s' on 'FINAL_OUTPUT' is invalid: %s", rt.XPath, err.Error())
+	}
+	return NewReader(name, r, rt.Decl, targetXPathExpr), nil
+}
+
+func (f *fixedLengthFormat) FmtErr(format string, args ...interface{}) error {
+	return fmt.Errorf("schema '%s': %s", f.schemaName, fmt.Sprintf(format, args...))
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/format_test.go
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/format_test.go
@@ -1,0 +1,297 @@
+package fixedlength
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/jf-tech/go-corelib/jsons"
+	"github.com/jf-tech/go-corelib/strs"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/errs"
+	"github.com/jf-tech/omniparser/extensions/omniv21/transform"
+	"github.com/jf-tech/omniparser/idr"
+)
+
+func TestValidateSchema(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		format      string
+		fileDecl    string
+		finalOutput *transform.Decl
+		err         string
+	}{
+		{
+			name:        "not supported format",
+			format:      "exe",
+			fileDecl:    "",
+			finalOutput: nil,
+			err:         errs.ErrSchemaNotSupported.Error(),
+		},
+		{
+			name:        "file_declaration JSON schema validation error",
+			format:      fileFormatFixedLength,
+			fileDecl:    `{}`,
+			finalOutput: nil,
+			err:         `schema 'test' validation failed: (root): file_declaration is required`,
+		},
+		{
+			name:   "group with rows",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{ "rows": 42, "type": "envelope_group" }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.envelopes.0.type: file_declaration.envelopes.0.type does not match: \"envelope\"\nfile_declaration.envelopes.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "group with header",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{ "header": ".", "type": "envelope_group" }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.envelopes.0.type: file_declaration.envelopes.0.type does not match: \"envelope\"\nfile_declaration.envelopes.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "group with columns",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{ "type": "envelope_group", "columns": [] }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.envelopes.0.type: file_declaration.envelopes.0.type does not match: \"envelope\"\nfile_declaration.envelopes.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "both rows and header/footer envelopes",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{ "rows": 42, "header": "^42$" }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.envelopes.0: Additional property rows is not allowed\nfile_declaration.envelopes.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "multiple target envelopes",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{ "name": "e1", "is_target": true },
+							{ "name": "e2", "is_target": true }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         `schema 'test': a second envelope/envelope_group ('e2') with 'is_target' = true is not allowed`,
+		},
+		{
+			name:   "invalid rows",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [ { "name": "e1", "rows": 0 } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.envelopes.0.rows: Must be greater than or equal to 1\nfile_declaration.envelopes.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "invalid header regex",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [ { "name": "e1", "header": "[" } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': envelope/envelope_group 'e1' has an invalid 'header' regexp '[': error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name:   "invalid footer regex",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [ { "name": "e1", "header": ".", "footer": "[" } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': envelope/envelope_group 'e1' has an invalid 'footer' regexp '[': error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name:   "invalid type",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [ { "name": "e1", "type": "test" } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.envelopes.0.type: file_declaration.envelopes.0.type does not match: \"envelope\"\nfile_declaration.envelopes.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "min > max",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [ { "name": "e1", "min": 5, "max": 4 } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': envelope/envelope_group 'e1' has 'min' value 5 > 'max' value 4",
+		},
+		{
+			name:   "invalid line_pattern regexp",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{
+								"name": "e1",
+								"columns": [{ "name": "c1", "start_pos": 1, "length": 3, "line_pattern": "[" }]
+							}
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': envelope 'e1' column 'c1' has an invalid 'line_pattern' regexp '[': error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name:   "FINAL_OUTPUT decl is nil",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{ "columns": [{ "name": "c1", "start_pos": 1, "length": 3 }] }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         `schema 'test': 'FINAL_OUTPUT' is missing`,
+		},
+		{
+			name:   "FINAL_OUTPUT xpath is invalid",
+			format: fileFormatFixedLength,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"envelopes" : []
+					}
+				}`,
+			finalOutput: &transform.Decl{XPath: strs.StrPtr("[")},
+			err:         `schema 'test': 'FINAL_OUTPUT.xpath' (value: '[') is invalid, err: expression must evaluate to a node-set`,
+		},
+		{
+			name:   "success",
+			format: fileFormatFixedLength,
+			fileDecl: `
+					{
+						"file_declaration": {
+							"envelopes" : [
+								{
+									"name": "e1", "type": "envelope_group", "min": 1, "max": 1,
+									"child_envelopes": [
+										{ "name": "e2", "max": 5, "columns": [{ "name": "c1", "start_pos": 1, "length": 3 }] },
+										{ "name": "e2", "header": "^ABC$", "columns": [{ "name": "c2", "start_pos": 2, "length": 5, "line_pattern": "^H00" }] }
+									]
+								}
+							]
+						}
+					}`,
+			finalOutput: &transform.Decl{XPath: strs.StrPtr(".[c1 != 'skip']")},
+			err:         "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runtime, err := NewFixedLengthFileFormat("test").
+				ValidateSchema(test.format, []byte(test.fileDecl), test.finalOutput)
+			if test.err != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+				assert.Nil(t, runtime)
+			} else {
+				assert.NoError(t, err)
+				cupaloy.SnapshotT(t, jsons.BPM(runtime))
+			}
+		})
+	}
+}
+
+func TestCreateFormatReader(t *testing.T) {
+	test := func(finalOutputXPath *string) {
+		format := NewFixedLengthFileFormat("test-schema")
+		runtime, err := format.ValidateSchema(
+			fileFormatFixedLength,
+			[]byte(`
+				{
+					"file_declaration": {
+						"envelopes" : [
+							{
+								"rows": 2,
+								"columns": [
+									{ "name": "letters", "start_pos": 1, "length": 3, "line_pattern": "^[a-z]" },
+									{ "name": "numerics", "start_pos": 1, "length": 3, "line_pattern": "^[0-9]" }
+								]
+							}
+						]
+					}
+				}`),
+			&transform.Decl{XPath: finalOutputXPath})
+		assert.NoError(t, err)
+		reader, err := format.CreateFormatReader(
+			"test-input",
+			strings.NewReader("abcd\n1234\n"),
+			runtime)
+		assert.NoError(t, err)
+		n, err := reader.Read()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"letters":"abc","numerics":"123"}`, idr.JSONify2(n))
+		reader.Release(n)
+		n, err = reader.Read()
+		assert.Equal(t, io.EOF, err)
+		assert.Nil(t, n)
+	}
+	test(nil)                                // test without FINAL_OUTPUT xpath filtering.
+	test(strs.StrPtr(".[letters != 'xyz']")) // test with FINAL_OUTPUT xpath filtering.
+
+	// test CreateFormatReader called with invalid target xpath.
+	reader, err := NewFixedLengthFileFormat("test-schema").CreateFormatReader(
+		"test-input",
+		strings.NewReader("abcd\n1234\n"),
+		&fixedLengthFormatRuntime{XPath: "["})
+	assert.Error(t, err)
+	assert.Equal(t,
+		"schema 'test-schema': xpath '[' on 'FINAL_OUTPUT' is invalid: expression must evaluate to a node-set",
+		err.Error())
+	assert.Nil(t, reader)
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/reader.go
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/reader.go
@@ -1,0 +1,248 @@
+package fixedlength
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/antchfx/xpath"
+	"github.com/jf-tech/go-corelib/ios"
+
+	"github.com/jf-tech/omniparser/extensions/omniv21/fileformat/flatfile"
+	"github.com/jf-tech/omniparser/idr"
+)
+
+type line struct {
+	lineNum int // 1-based
+	b       []byte
+}
+
+type reader struct {
+	inputName string
+	r         *bufio.Reader
+	hr        *flatfile.HierarchyReader
+	linesRead int    // total number of lines read in so far
+	linesBuf  []line // linesBuf contains all the unprocessed lines
+}
+
+// NewReader creates an FormatReader for fixed-length file format.
+func NewReader(
+	inputName string, r io.Reader, decl *FileDecl, targetXPathExpr *xpath.Expr) *reader {
+	reader := &reader{
+		inputName: inputName,
+		r:         bufio.NewReader(r),
+	}
+	reader.hr = flatfile.NewHierarchyReader(
+		toFlatFileRecDecls(decl.Envelopes), reader, targetXPathExpr)
+	return reader
+}
+
+// Read implements fileformat.FormatReader interface, reading in data from input and returns
+// target IDR node.
+func (r *reader) Read() (*idr.Node, error) {
+	n, err := r.hr.Read()
+	switch {
+	case err == nil:
+		return n, nil
+	case flatfile.IsErrFewerThanMinOccurs(err):
+		e := err.(flatfile.ErrFewerThanMinOccurs)
+		envelopeDecl := e.RecDecl.(*EnvelopeDecl)
+		return nil, ErrInvalidFixedLength(r.fmtErrStr(r.unprocessedLineNum(),
+			"envelope/envelope_group '%s' needs min occur %d, but only got %d",
+			envelopeDecl.fqdn, envelopeDecl.MinOccurs(), e.ActualOcccurs))
+	case flatfile.IsErrUnexpectedData(err):
+		return nil, ErrInvalidFixedLength(r.fmtErrStr(r.unprocessedLineNum(), "unexpected data"))
+	default:
+		return nil, err
+	}
+}
+
+// MoreUnprocessedData implements flatfile.RecReader, telling whether there is still unprocessed
+// data or not.
+func (r *reader) MoreUnprocessedData() (bool, error) {
+	if len(r.linesBuf) > 0 {
+		return true, nil
+	}
+	if err := r.readLine(); err != nil && err != io.EOF {
+		return false, err
+	}
+	return len(r.linesBuf) > 0, nil
+}
+
+// ReadAndMatch implements flatfile.RecReader, reading unprocessed data (from buffer or from IO),
+// trying to match against the given non-group typed record decl, and converting the data into IDR
+// node if asked to.
+func (r *reader) ReadAndMatch(
+	decl flatfile.RecDecl, createIDR bool) (matched bool, node *idr.Node, err error) {
+	envelopeDecl := decl.(*EnvelopeDecl)
+	if envelopeDecl.rowsBased() {
+		return r.readAndMatchRowsBasedEnvelope(envelopeDecl, createIDR)
+	}
+	return r.readAndMatchHeaderFooterBasedEnvelope(envelopeDecl, createIDR)
+}
+
+func (r *reader) readAndMatchRowsBasedEnvelope(
+	decl *EnvelopeDecl, createNode bool) (bool, *idr.Node, error) {
+	for len(r.linesBuf) < decl.rows() {
+		if err := r.readLine(); err != nil {
+			if err != io.EOF || len(r.linesBuf) == 0 {
+				// So either the err isn't io.EOF, we need to return this critical error directly;
+				// or it's io.EOF and our line buf is empty, i.e. all has been procssed, so we
+				// should return io.EOF to indicate end. Both case, we simply return "not matched"
+				// plus err.
+				return false, nil, err
+			}
+			// we're here when the err is io.EOF and line buf isn't empty, so we return
+			// "no match", and "no error", hoping the non-empty line buf will be matched
+			// by subsequent calls with different decls.
+			return false, nil, nil
+		}
+	}
+	if createNode {
+		n := r.linesToNode(decl, decl.rows())
+		// Once those rows have been converted into IDR node, we're done with them, and remove
+		// them from the unprocessed line buffer.
+		r.popFrontLinesBuf(decl.rows())
+		return true, n, nil
+	}
+	return true, nil, nil
+}
+
+func (r *reader) readAndMatchHeaderFooterBasedEnvelope(
+	decl *EnvelopeDecl, createNode bool) (bool, *idr.Node, error) {
+	if len(r.linesBuf) <= 0 {
+		if err := r.readLine(); err != nil {
+			// io.EOF or not, since r.linesBuf is empty, we can directly return err.
+			return false, nil, err
+		}
+	}
+	if !decl.matchHeader(r.linesBuf[0].b) {
+		return false, nil, nil
+	}
+	i := 0 // we'll match the footer starting on the same line.
+	for {
+		if decl.matchFooter(r.linesBuf[i].b) {
+			if createNode {
+				n := r.linesToNode(decl, i+1)
+				r.popFrontLinesBuf(i + 1)
+				return true, n, nil
+			}
+			return true, nil, nil
+		}
+		// if by the end of r.linesBuf we still haven't matched footer, we need to
+		// read more line in for footer match.
+		if i >= len(r.linesBuf)-1 {
+			if err := r.readLine(); err != nil {
+				if err != io.EOF { // io reading error, directly return err.
+					return false, nil, err
+				}
+				// io.EOF encountered and since r.linesBuf isn't empty,
+				// we need to return false for matching, but nil for error (we only return io.EOF
+				// when r.linesBuf is empty.
+				return false, nil, nil
+			}
+		}
+		i++
+	}
+}
+
+func (r *reader) readLine() error {
+	for {
+		// note1: ios.ByteReadLine returns a ln with trailing '\n' (and/or '\r') dropped.
+		// note2: ios.ByteReadLine won't return io.EOF if ln returned isn't empty.
+		b, err := ios.ByteReadLine(r.r)
+		switch {
+		case err == io.EOF:
+			return io.EOF
+		case err != nil:
+			return ErrInvalidFixedLength(r.fmtErrStr(r.linesRead+1, err.Error()))
+		}
+		r.linesRead++
+		if len(b) > 0 {
+			r.linesBuf = append(r.linesBuf, line{lineNum: r.linesRead, b: b})
+			return nil
+		}
+	}
+}
+
+func (r *reader) linesToNode(decl *EnvelopeDecl, n int) *idr.Node {
+	if len(r.linesBuf) < n {
+		panic(
+			fmt.Sprintf("linesBuf has %d lines but requested %d lines to convert",
+				len(r.linesBuf), n))
+	}
+	node := idr.CreateNode(idr.ElementNode, decl.Name)
+	for col := range decl.Columns {
+		colDecl := decl.Columns[col]
+		for i := 0; i < n; i++ {
+			if !colDecl.lineMatch(i, r.linesBuf[i].b) {
+				continue
+			}
+			colNode := idr.CreateNode(idr.ElementNode, colDecl.Name)
+			idr.AddChild(node, colNode)
+			colVal := idr.CreateNode(idr.TextNode, colDecl.lineToColumnValue(r.linesBuf[i].b))
+			idr.AddChild(colNode, colVal)
+		}
+	}
+	return node
+}
+
+func (r *reader) popFrontLinesBuf(n int) {
+	if n > len(r.linesBuf) {
+		panic(fmt.Sprintf(
+			"less lines (%d) in r.linesBuf than requested pop front count (%d)",
+			len(r.linesBuf), n))
+	}
+	newLen := len(r.linesBuf) - n
+	for i := 0; i < newLen; i++ {
+		r.linesBuf[i] = r.linesBuf[i+n]
+	}
+	r.linesBuf = r.linesBuf[:newLen]
+}
+
+func (r *reader) unprocessedLineNum() int {
+	if len(r.linesBuf) > 0 {
+		return r.linesBuf[0].lineNum
+	}
+	return r.linesRead + 1
+}
+
+// Release implements fileformat.FormatReader interface, releasing a finished IDR target node.
+func (r *reader) Release(n *idr.Node) {
+	r.hr.Release(n)
+}
+
+// IsContinuableError implements fileformat..FormatReader interface, checking if an error is
+// fatal or not.
+func (r *reader) IsContinuableError(err error) bool {
+	return !IsErrInvalidFixedLength(err) && err != io.EOF
+}
+
+// FmtErr implements errs.CtxAwareErr embedded in fileformat.FormatReader, formatting an error
+// with line info.
+func (r *reader) FmtErr(format string, args ...interface{}) error {
+	return errors.New(r.fmtErrStr(r.unprocessedLineNum(), format, args...))
+}
+
+func (r *reader) fmtErrStr(line int, format string, args ...interface{}) string {
+	return fmt.Sprintf("input '%s' line %d: %s",
+		r.inputName, line, fmt.Sprintf(format, args...))
+}
+
+// ErrInvalidFixedLength indicates the fixed-length content is corrupted or IO failure.
+// This is a fatal, non-continuable error.
+type ErrInvalidFixedLength string
+
+// Error implements error interface.
+func (e ErrInvalidFixedLength) Error() string { return string(e) }
+
+// IsErrInvalidFixedLength checks if the `err` is of ErrInvalidFixedLength type.
+func IsErrInvalidFixedLength(err error) bool {
+	switch err.(type) {
+	case ErrInvalidFixedLength:
+		return true
+	default:
+		return false
+	}
+}

--- a/extensions/omniv21/fileformat/flatfile/fixedlength/reader_test.go
+++ b/extensions/omniv21/fileformat/flatfile/fixedlength/reader_test.go
@@ -1,0 +1,502 @@
+package fixedlength
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/jf-tech/go-corelib/strs"
+	"github.com/jf-tech/go-corelib/testlib"
+	"github.com/jf-tech/omniparser/extensions/omniv21/transform"
+	"github.com/jf-tech/omniparser/idr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRead(t *testing.T) {
+	format := NewFixedLengthFileFormat("test-schema")
+	rt, err := format.ValidateSchema(
+		fileFormatFixedLength,
+		[]byte(`
+			{
+				"file_declaration": {
+					"envelopes" : [
+						{
+							"name": "e1", "type": "envelope_group", "is_target": true,
+							"child_envelopes": [
+								{
+									"name": "e2", "header": "^e2h", "footer": "^e2t", "min": 1, "max": 1,
+									"columns": [
+										{ "name": "c2", "start_pos": 5, "length": 1, "line_pattern": "^e2b" }
+									]
+								},
+								{
+									"name": "e3", "rows": 2, "min": 1, "max": 2,
+									"columns": [
+										{ "name": "c31", "start_pos": 1, "length": 1, "line_index": 1 },
+										{ "name": "c32", "start_pos": 1, "length": 1, "line_index": 2 }
+									]
+								},
+								{
+									"name": "e4", "header": "^e4h", "min": 1, "max": 1,
+									"columns": [
+										{ "name": "c4", "start_pos": 5, "length": 1 }
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		`),
+		&transform.Decl{})
+	assert.NoError(t, err)
+	for _, test := range []struct {
+		name string
+		r    io.Reader
+		err  string
+	}{
+		{
+			name: "empty input",
+			r:    strings.NewReader(""),
+			err:  io.EOF.Error(),
+		},
+		{
+			name: "e4 min occurs not satisified",
+			r:    strings.NewReader("e2h\ne2b:1\ne2t\n1-line\n2-line\n3-line\n"),
+			err:  "input 'test-input' line 6: envelope/envelope_group 'e1/e4' needs min occur 1, but only got 0",
+		},
+		{
+			name: "unexpected data",
+			r:    strings.NewReader("1-line\n"),
+			err:  "input 'test-input' line 1: unexpected data",
+		},
+		{
+			name: "success",
+			r:    strings.NewReader("e2h\ne2b:2\ne2t\n1-line\n2-line\n3-line\n4-line\ne4h:4\n"),
+			err:  "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r, err := format.CreateFormatReader("test-input", test.r, rt)
+			assert.NoError(t, err)
+			n, err := r.Read()
+			if strs.IsStrNonBlank(test.err) {
+				assert.Nil(t, n)
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+			} else {
+				assert.NotNil(t, n)
+				assert.NoError(t, err)
+				cupaloy.SnapshotT(t, idr.JSONify1(n))
+			}
+		})
+	}
+}
+
+func TestMoreUnprocessedData(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		lines   []string
+		r       io.Reader
+		expMore bool
+		expErr  string
+	}{
+		{
+			name:    "linesBuf not empty",
+			lines:   []string{""},
+			expMore: true,
+			expErr:  "",
+		},
+		{
+			name:    "linesBuf empty; io error",
+			r:       testlib.NewMockReadCloser("io error", nil),
+			expMore: false,
+			expErr:  "input 'test-input' line 1: io error",
+		},
+		{
+			name:    "linesBuf empty; io.EOF",
+			r:       strings.NewReader(""),
+			expMore: false,
+			expErr:  "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := &reader{
+				inputName: "test-input",
+			}
+			if len(test.lines) > 0 {
+				r.linesRead = len(test.lines)
+				r.linesBuf = make([]line, len(test.lines))
+				for i := range test.lines {
+					r.linesBuf[i] = line{lineNum: i + 1, b: []byte(test.lines[i])}
+				}
+			}
+			if test.r != nil {
+				r.r = bufio.NewReader(test.r)
+			}
+			more, err := r.MoreUnprocessedData()
+			assert.Equal(t, test.expMore, more)
+			if strs.IsStrNonBlank(test.expErr) {
+				assert.Error(t, err)
+				assert.Equal(t, test.expErr, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadAndMatchRowsBasedEnvelope(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		linesBuf       []string
+		r              io.Reader
+		decl           *EnvelopeDecl
+		createIDR      bool
+		expMatch       bool
+		expIDR         bool
+		expErr         string
+		expLinesRemain int
+	}{
+		{
+			name:           "non-empty buf; io read err",
+			linesBuf:       []string{"line 1"},
+			r:              testlib.NewMockReadCloser("io error", nil),
+			decl:           &EnvelopeDecl{Rows: testlib.IntPtr(2)},
+			createIDR:      false,
+			expMatch:       false,
+			expIDR:         false,
+			expErr:         "input 'test-input' line 2: io error",
+			expLinesRemain: 1,
+		},
+		{
+			name:           "empty buf; io.EOF",
+			linesBuf:       nil,
+			r:              strings.NewReader(""),
+			decl:           &EnvelopeDecl{Rows: testlib.IntPtr(2)},
+			createIDR:      false,
+			expMatch:       false,
+			expIDR:         false,
+			expErr:         io.EOF.Error(),
+			expLinesRemain: 0,
+		},
+		{
+			name:           "non-empty buf; io.EOF",
+			linesBuf:       []string{"line 1"},
+			r:              strings.NewReader(""),
+			decl:           &EnvelopeDecl{Rows: testlib.IntPtr(2)},
+			createIDR:      false,
+			expMatch:       false,
+			expIDR:         false,
+			expErr:         "",
+			expLinesRemain: 1,
+		},
+		{
+			name:     "non-empty buf; no read; match; create IDR",
+			linesBuf: []string{"line 1", "line 2", "line 3"},
+			r:        strings.NewReader(""),
+			decl: &EnvelopeDecl{
+				Name: "E",
+				Rows: testlib.IntPtr(2),
+				Columns: []*ColumnDecl{
+					{Name: "C1", StartPos: 6, Length: 1, LineIndex: testlib.IntPtr(1)},
+					{Name: "C2", StartPos: 6, Length: 1, LineIndex: testlib.IntPtr(2)},
+				},
+			},
+			createIDR:      true,
+			expMatch:       true,
+			expIDR:         true,
+			expErr:         "",
+			expLinesRemain: 1,
+		},
+		{
+			name:     "empty buf; read; match; no IDR",
+			linesBuf: nil,
+			r:        strings.NewReader("line 1\n"),
+			decl:     &EnvelopeDecl{
+				// Rows == nil, use default value 1
+			},
+			createIDR:      false,
+			expMatch:       true,
+			expIDR:         false,
+			expErr:         "",
+			expLinesRemain: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := &reader{
+				inputName: "test-input",
+				linesRead: len(test.linesBuf),
+				r:         bufio.NewReader(test.r),
+			}
+			r.linesBuf = make([]line, len(test.linesBuf))
+			for i := range test.linesBuf {
+				r.linesBuf[i] = line{lineNum: i + 1, b: []byte(test.linesBuf[i])}
+			}
+			matched, node, err := r.readAndMatchRowsBasedEnvelope(test.decl, test.createIDR)
+			assert.Equal(t, test.expMatch, matched)
+			if test.expIDR {
+				assert.NotNil(t, node)
+				cupaloy.SnapshotT(t, idr.JSONify1(node))
+			} else {
+				assert.Nil(t, node)
+			}
+			if strs.IsStrNonBlank(test.expErr) {
+				assert.Error(t, err)
+				assert.Equal(t, test.expErr, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.expLinesRemain, len(r.linesBuf))
+		})
+	}
+}
+
+func TestReadAndMatchHeaderFooterBasedEnvelope(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		linesBuf       []string
+		r              io.Reader
+		decl           *EnvelopeDecl
+		createIDR      bool
+		expMatch       bool
+		expIDR         bool
+		expErr         string
+		expLinesRemain int
+	}{
+		{
+			name:           "empty buf; io read err",
+			linesBuf:       nil,
+			r:              testlib.NewMockReadCloser("io error", nil),
+			decl:           nil,
+			createIDR:      false,
+			expMatch:       false,
+			expIDR:         false,
+			expErr:         "input 'test-input' line 1: io error",
+			expLinesRemain: 0,
+		},
+		{
+			name:           "non-empty buf; header not match",
+			linesBuf:       []string{"line 1"},
+			r:              testlib.NewMockReadCloser("io error", nil), // shouldn't be called
+			decl:           &EnvelopeDecl{headerRegexp: regexp.MustCompile("^header")},
+			createIDR:      false,
+			expMatch:       false,
+			expIDR:         false,
+			expErr:         "",
+			expLinesRemain: 1,
+		},
+		{
+			name:     "empty buf; single line header/footer match",
+			linesBuf: nil,
+			r:        strings.NewReader("line 1"),
+			decl: &EnvelopeDecl{
+				Name:         "E",
+				Columns:      []*ColumnDecl{{Name: "C", StartPos: 6, Length: 1}},
+				headerRegexp: regexp.MustCompile("^line"),
+			},
+			createIDR:      true,
+			expMatch:       true,
+			expIDR:         true,
+			expErr:         "",
+			expLinesRemain: 0,
+		},
+		{
+			name:     "1-line buf; 3-line header/footer match",
+			linesBuf: []string{"ABCEFG"},
+			r:        strings.NewReader("hello\n123456\n"),
+			decl: &EnvelopeDecl{
+				Name: "E",
+				Columns: []*ColumnDecl{{
+					Name:              "C",
+					StartPos:          4,
+					Length:            2,
+					linePatternRegexp: regexp.MustCompile("^he"),
+				}},
+				headerRegexp: regexp.MustCompile("^ABC"),
+				footerRegexp: regexp.MustCompile("^123"),
+			},
+			createIDR:      false,
+			expMatch:       true,
+			expIDR:         false,
+			expErr:         "",
+			expLinesRemain: 3, // it's a match, but no idr created, so the lines remain cached
+		},
+		{
+			name:     "1-line buf; header matches, footer line read io error",
+			linesBuf: []string{"ABCEFG"},
+			r:        testlib.NewMockReadCloser("io error", nil),
+			decl: &EnvelopeDecl{
+				headerRegexp: regexp.MustCompile("^ABC"),
+				footerRegexp: regexp.MustCompile("^123"),
+			},
+			createIDR:      false,
+			expMatch:       false,
+			expIDR:         false,
+			expErr:         "input 'test-input' line 2: io error",
+			expLinesRemain: 1,
+		},
+		{
+			name:     "1-line buf; header matches, footer line read io.EOF",
+			linesBuf: []string{"ABCEFG"},
+			r:        strings.NewReader(""),
+			decl: &EnvelopeDecl{
+				headerRegexp: regexp.MustCompile("^ABC"),
+				footerRegexp: regexp.MustCompile("^123"),
+			},
+			createIDR:      false,
+			expMatch:       false,
+			expIDR:         false,
+			expErr:         "",
+			expLinesRemain: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := &reader{
+				inputName: "test-input",
+				linesRead: len(test.linesBuf),
+				r:         bufio.NewReader(test.r),
+			}
+			r.linesBuf = make([]line, len(test.linesBuf))
+			for i := range test.linesBuf {
+				r.linesBuf[i] = line{lineNum: i + 1, b: []byte(test.linesBuf[i])}
+			}
+			matched, node, err := r.readAndMatchHeaderFooterBasedEnvelope(test.decl, test.createIDR)
+			assert.Equal(t, test.expMatch, matched)
+			if test.expIDR {
+				assert.NotNil(t, node)
+				cupaloy.SnapshotT(t, idr.JSONify1(node))
+			} else {
+				assert.Nil(t, node)
+			}
+			if strs.IsStrNonBlank(test.expErr) {
+				assert.Error(t, err)
+				assert.Equal(t, test.expErr, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.expLinesRemain, len(r.linesBuf))
+		})
+	}
+}
+
+func TestReadLine(t *testing.T) {
+	r := &reader{
+		inputName: "test-input",
+		linesRead: 42,
+		linesBuf: []line{
+			{lineNum: 41, b: []byte("line 41")},
+			{lineNum: 42, b: []byte("line 42")},
+		},
+	}
+	r.r = bufio.NewReader(strings.NewReader(""))
+	err := r.readLine()
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, 42, r.linesRead)
+	assert.Equal(t, 2, len(r.linesBuf))
+	r.r = bufio.NewReader(testlib.NewMockReadCloser("test error", nil))
+	err = r.readLine()
+	assert.Error(t, err)
+	assert.Equal(t, "input 'test-input' line 43: test error", err.Error())
+	assert.Equal(t, 42, r.linesRead)
+	assert.Equal(t, 2, len(r.linesBuf))
+	r.r = bufio.NewReader(strings.NewReader("\n\na new line"))
+	err = r.readLine()
+	assert.NoError(t, err)
+	assert.Equal(t, 45, r.linesRead)
+	assert.Equal(t, 3, len(r.linesBuf))
+	assert.Equal(t, line{lineNum: 45, b: []byte("a new line")}, r.linesBuf[2])
+}
+
+func TestLinesToNode(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		lines    [][]byte
+		n        int
+		cols     []*ColumnDecl
+		panicStr string
+	}{
+		{
+			name:     "n > len(lines)",
+			lines:    [][]byte{{}},
+			n:        3,
+			panicStr: "linesBuf has 1 lines but requested 3 lines to convert",
+		},
+		{
+			name: "line matches",
+			lines: [][]byte{
+				[]byte("abc"),
+				[]byte("hello, world"),
+				[]byte("1234"),
+				[]byte("#$%^"),
+			},
+			n: 3,
+			cols: []*ColumnDecl{
+				{Name: "W", StartPos: 8, Length: 5, linePatternRegexp: regexp.MustCompile("^hello")},
+				{Name: "C", StartPos: 3, Length: 1, LineIndex: testlib.IntPtr(1)},
+				{Name: "0", StartPos: 1, Length: 1, linePatternRegexp: regexp.MustCompile("no-match")},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			r := &reader{}
+			r.linesBuf = make([]line, len(test.lines))
+			for i := range test.lines {
+				r.linesBuf[i] = line{lineNum: i, b: test.lines[i]}
+			}
+			if strs.IsStrNonBlank(test.panicStr) {
+				assert.PanicsWithValue(t, test.panicStr, func() {
+					r.linesToNode(
+						&EnvelopeDecl{Name: "test-envelope", Columns: test.cols},
+						test.n)
+				})
+			} else {
+				node := r.linesToNode(
+					&EnvelopeDecl{Name: "test-envelope", Columns: test.cols},
+					test.n)
+				cupaloy.SnapshotT(t, idr.JSONify1(node))
+			}
+		})
+	}
+}
+
+func TestPopFrontLinesBuf(t *testing.T) {
+	r := &reader{}
+	r.linesBuf = make([]line, 3, 10)
+	r.linesBuf[0] = line{lineNum: 10, b: []byte("a")}
+	r.linesBuf[1] = line{lineNum: 11, b: []byte("b")}
+	r.linesBuf[2] = line{lineNum: 12, b: []byte("c")}
+	assert.PanicsWithValue(t,
+		"less lines (3) in r.linesBuf than requested pop front count (5)",
+		func() { r.popFrontLinesBuf(5) })
+	assert.Equal(t, 3, len(r.linesBuf))
+	assert.Equal(t, 10, cap(r.linesBuf))
+	r.popFrontLinesBuf(2)
+	assert.Equal(t, 1, len(r.linesBuf))
+	assert.Equal(t, 10, cap(r.linesBuf))
+	assert.Equal(t, line{lineNum: 12, b: []byte("c")}, r.linesBuf[0])
+}
+
+func TestUnprocessedLineNum(t *testing.T) {
+	r := &reader{linesRead: 42}
+	assert.Equal(t, 42+1, r.unprocessedLineNum())
+	r.linesBuf = []line{{lineNum: 13}}
+	assert.Equal(t, 13, r.unprocessedLineNum())
+}
+
+func TestIsContinuableError(t *testing.T) {
+	r := &reader{}
+	assert.True(t, r.IsContinuableError(r.FmtErr("some error")))
+	assert.False(t, r.IsContinuableError(ErrInvalidFixedLength("invalid envelope")))
+	assert.False(t, r.IsContinuableError(io.EOF))
+}
+
+func TestIsErrInvalidFixedLength(t *testing.T) {
+	assert.True(t, IsErrInvalidFixedLength(ErrInvalidFixedLength("test")))
+	assert.Equal(t, "test", ErrInvalidFixedLength("test").Error())
+	assert.False(t, IsErrInvalidFixedLength(errors.New("test")))
+}


### PR DESCRIPTION
Next steps:
- enable it from omnniv21 schema handler
- add samples
- add more end to end integration tests
- update cli server sample collection
- documentation on 'fixed-length2', deprecation of 'fixed-length' and migration strategy.