### PR TITLE
Adding column index and line matching attributes (line_index, and line_pattern) to csv2 column decl and json validation schema

### DIFF
--- a/extensions/omniv21/fileformat/flatfile/csv/.snapshots/TestValidateFileDecl_Success
+++ b/extensions/omniv21/fileformat/flatfile/csv/.snapshots/TestValidateFileDecl_Success
@@ -1,0 +1,23 @@
+([]*csv.ColumnDecl) (len=3) {
+  (*csv.ColumnDecl)({
+    Name: (string) (len=2) "c1",
+    Index: (*int)(1),
+    LineIndex: (*int)(1),
+    LinePattern: (*string)(<nil>),
+    linePatternRegexp: (*regexp.Regexp)(<nil>)
+  }),
+  (*csv.ColumnDecl)({
+    Name: (string) (len=2) "c2",
+    Index: (*int)(3),
+    LineIndex: (*int)(<nil>),
+    LinePattern: (*string)(<nil>),
+    linePatternRegexp: (*regexp.Regexp)(<nil>)
+  }),
+  (*csv.ColumnDecl)({
+    Name: (string) (len=2) "c3",
+    Index: (*int)(4),
+    LineIndex: (*int)(<nil>),
+    LinePattern: (*string)((len=3) "^C$"),
+    linePatternRegexp: (*regexp.Regexp)(^C$)
+  })
+}

--- a/extensions/omniv21/fileformat/flatfile/csv/decl_test.go
+++ b/extensions/omniv21/fileformat/flatfile/csv/decl_test.go
@@ -11,6 +11,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestColumnDecl_LineMatch(t *testing.T) {
+	assert.True(t, (&ColumnDecl{}).lineMatch(0, line{}))
+	assert.False(t, (&ColumnDecl{LineIndex: testlib.IntPtr(2)}).lineMatch(0, line{}))
+	assert.True(t, (&ColumnDecl{LineIndex: testlib.IntPtr(2)}).lineMatch(1, line{}))
+	assert.False(t, (&ColumnDecl{linePatternRegexp: regexp.MustCompile("^ABC.*$")}).
+		lineMatch(0, line{raw: "1234567"}))
+	assert.True(t, (&ColumnDecl{linePatternRegexp: regexp.MustCompile("^ABC.*$")}).
+		lineMatch(0, line{raw: "ABCDEFG"}))
+}
+
+func TestColumnDecl_LineToColumnValue(t *testing.T) {
+	assert.Equal(t, "", (&ColumnDecl{Index: testlib.IntPtr(2)}).lineToColumnValue(
+		line{record: []string{"1"}})) // index out of range
+	assert.Equal(t, "", (&ColumnDecl{Index: testlib.IntPtr(0)}).lineToColumnValue(
+		line{record: []string{"1"}})) // index out of range
+	assert.Equal(t, "9", (&ColumnDecl{Index: testlib.IntPtr(5)}).lineToColumnValue(
+		line{record: []string{"1", "3", "5", "7", "9", "11"}})) // in range
+}
+
 func TestRecordDecl(t *testing.T) {
 	// DeclName()
 	r := &RecordDecl{Name: "r1"}

--- a/extensions/omniv21/fileformat/flatfile/csv/line.go
+++ b/extensions/omniv21/fileformat/flatfile/csv/line.go
@@ -1,0 +1,7 @@
+package csv
+
+type line struct {
+	lineNum int // 1-based
+	record  []string
+	raw     string
+}

--- a/extensions/omniv21/fileformat/flatfile/csv/validate.go
+++ b/extensions/omniv21/fileformat/flatfile/csv/validate.go
@@ -62,11 +62,50 @@ func (ctx *validateCtx) validateRecordDecl(fqdn string, decl *RecordDecl) (err e
 		return fmt.Errorf("record/record_group '%s' has 'min' value %d > 'max' value %d",
 			fqdn, decl.MinOccurs(), decl.MaxOccurs())
 	}
+	for i, col := range decl.Columns {
+		prevCol := (*ColumnDecl)(nil)
+		if i > 0 {
+			prevCol = decl.Columns[i-1]
+		}
+		if err = ctx.validateColumnDecl(fqdn, prevCol, col); err != nil {
+			return err
+		}
+	}
 	for _, c := range decl.Children {
 		if err = ctx.validateRecordDecl(strs.BuildFQDN2("/", fqdn, c.Name), c); err != nil {
 			return err
 		}
 	}
 	decl.childRecDecls = toFlatFileRecDecls(decl.Children)
+	return nil
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func (ctx *validateCtx) validateColumnDecl(fqdn string, prevDecl, decl *ColumnDecl) (err error) {
+	// If column.index not specified, then we'll use the previous column's index value + 1 unless
+	// the column is the first column, then 1 will be used.
+	// if column.index is explicitly specified, it will be honored.
+	if decl.Index == nil {
+		if prevDecl == nil {
+			decl.Index = intPtr(1)
+		} else {
+			decl.Index = intPtr(*prevDecl.Index + 1)
+		}
+	}
+	if decl.LineIndex != nil && decl.LinePattern != nil {
+		return fmt.Errorf(
+			"record '%s' column '%s' cannot have both `line_index` and `line_pattern` specified at the same time",
+			fqdn, decl.Name)
+	}
+	if decl.LinePattern != nil {
+		if decl.linePatternRegexp, err = caches.GetRegex(*decl.LinePattern); err != nil {
+			return fmt.Errorf(
+				"record '%s' column '%s' has an invalid 'line_pattern' regexp '%s': %s",
+				fqdn, decl.Name, *decl.LinePattern, err.Error())
+		}
+	}
 	return nil
 }

--- a/extensions/omniv21/validation/csv2FileDeclaration.go
+++ b/extensions/omniv21/validation/csv2FileDeclaration.go
@@ -84,7 +84,10 @@ const (
             "items": {
                 "type": "object",
                 "properties": {
-                    "name": { "type": "string", "minLength": 1 }
+                    "name": { "type": "string", "minLength": 1 },
+                    "index": { "type": "integer", "minimum": 1 },
+                    "line_index": { "type": "integer", "minimum": 1 },
+                    "line_pattern": { "type": "string", "minLength": 1 }
                 },
                 "required": [ "name" ],
                 "additionalProperties": false

--- a/extensions/omniv21/validation/csv2FileDeclaration.json
+++ b/extensions/omniv21/validation/csv2FileDeclaration.json
@@ -77,7 +77,10 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "name": { "type": "string", "minLength": 1 }
+                    "name": { "type": "string", "minLength": 1 },
+                    "index": { "type": "integer", "minimum": 1 },
+                    "line_index": { "type": "integer", "minimum": 1 },
+                    "line_pattern": { "type": "string", "minLength": 1 }
                 },
                 "required": [ "name" ],
                 "additionalProperties": false


### PR DESCRIPTION
Turns out if we want to support multi-line record (whether it's fixed number of rows based or header/footer based) in csv we will have to let each column to specify which line the column value should come from, and of that particular line, which indexed value to use, thus the adding of `index`, `line_index` and `line_pattern`.