### PR TITLE
Adding csv2 file format. Fixing a major bug in the `csv2.reader` implementation

### DIFF
--- a/extensions/omniv21/fileformat/flatfile/csv/.snapshots/TestRead-multiple_records
+++ b/extensions/omniv21/fileformat/flatfile/csv/.snapshots/TestRead-multiple_records
@@ -4,7 +4,7 @@
 			"Children": [
 				{
 					"Children": null,
-					"Data": "v3",
+					"Data": "v1",
 					"FirstChild": null,
 					"FormatSpecific": null,
 					"LastChild": null,
@@ -15,9 +15,9 @@
 				}
 			],
 			"Data": "r1c1",
-			"FirstChild": "(TextNode 'v3')",
+			"FirstChild": "(TextNode 'v1')",
 			"FormatSpecific": null,
-			"LastChild": "(TextNode 'v3')",
+			"LastChild": "(TextNode 'v1')",
 			"NextSibling": "(ElementNode r1c2)",
 			"Parent": "(ElementNode r1)",
 			"PrevSibling": null,

--- a/extensions/omniv21/fileformat/flatfile/csv/.snapshots/TestValidateSchema-success
+++ b/extensions/omniv21/fileformat/flatfile/csv/.snapshots/TestValidateSchema-success
@@ -1,0 +1,38 @@
+{
+	"file_declaration": {
+		"delimiter": ",",
+		"records": [
+			{
+				"name": "e1",
+				"type": "record_group",
+				"is_target": true,
+				"min": 1,
+				"max": 1,
+				"child_records": [
+					{
+						"name": "e2",
+						"max": 5,
+						"columns": [
+							{
+								"name": "c1",
+								"index": 2
+							}
+						]
+					},
+					{
+						"name": "e2",
+						"header": "^ABC$",
+						"columns": [
+							{
+								"name": "c2",
+								"index": 1,
+								"line_pattern": "^H00"
+							}
+						]
+					}
+				]
+			}
+		]
+	},
+	"XPath": ".[c1 != 'skip']"
+}

--- a/extensions/omniv21/fileformat/flatfile/csv/format.go
+++ b/extensions/omniv21/fileformat/flatfile/csv/format.go
@@ -1,0 +1,95 @@
+package csv
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/antchfx/xpath"
+	"github.com/jf-tech/go-corelib/caches"
+	"github.com/jf-tech/go-corelib/strs"
+
+	"github.com/jf-tech/omniparser/errs"
+	"github.com/jf-tech/omniparser/extensions/omniv21/fileformat"
+	"github.com/jf-tech/omniparser/extensions/omniv21/transform"
+	v21validation "github.com/jf-tech/omniparser/extensions/omniv21/validation"
+	"github.com/jf-tech/omniparser/validation"
+)
+
+const (
+	fileFormatCSV = "csv2"
+)
+
+type csvFormat struct {
+	schemaName string
+}
+
+// NewCSVFileFormat creates a FileFormat for 'csv2'.
+func NewCSVFileFormat(schemaName string) fileformat.FileFormat {
+	return &csvFormat{schemaName: schemaName}
+}
+
+type csvFormatRuntime struct {
+	Decl  *FileDecl `json:"file_declaration"`
+	XPath string
+}
+
+func (f *csvFormat) ValidateSchema(
+	format string, schemaContent []byte, finalOutputDecl *transform.Decl) (interface{}, error) {
+	if format != fileFormatCSV {
+		return nil, errs.ErrSchemaNotSupported
+	}
+	err := validation.SchemaValidate(
+		f.schemaName, schemaContent, v21validation.JSONSchemaCSV2FileDeclaration)
+	if err != nil {
+		// err is already context formatted.
+		return nil, err
+	}
+	var runtime csvFormatRuntime
+	_ = json.Unmarshal(schemaContent, &runtime) // JSON schema validation earlier guarantees Unmarshal success.
+	err = f.validateFileDecl(runtime.Decl)
+	if err != nil {
+		// err is already context formatted.
+		return nil, err
+	}
+	if finalOutputDecl == nil {
+		return nil, f.FmtErr("'FINAL_OUTPUT' is missing")
+	}
+	runtime.XPath = strings.TrimSpace(strs.StrPtrOrElse(finalOutputDecl.XPath, ""))
+	if runtime.XPath != "" {
+		_, err := caches.GetXPathExpr(runtime.XPath)
+		if err != nil {
+			return nil, f.FmtErr("'FINAL_OUTPUT.xpath' (value: '%s') is invalid, err: %s",
+				runtime.XPath, err.Error())
+		}
+	}
+	return &runtime, nil
+}
+
+func (f *csvFormat) validateFileDecl(decl *FileDecl) error {
+	err := (&validateCtx{}).validateFileDecl(decl)
+	if err != nil {
+		return f.FmtErr(err.Error())
+	}
+	return err
+}
+
+func (f *csvFormat) CreateFormatReader(
+	name string, r io.Reader, runtime interface{}) (fileformat.FormatReader, error) {
+	rt := runtime.(*csvFormatRuntime)
+	targetXPathExpr, err := func() (*xpath.Expr, error) {
+		if rt.XPath == "" || rt.XPath == "." {
+			return nil, nil
+		}
+		return caches.GetXPathExpr(rt.XPath)
+	}()
+	if err != nil {
+		return nil, f.FmtErr("xpath '%s' on 'FINAL_OUTPUT' is invalid: %s", rt.XPath, err.Error())
+	}
+	return NewReader(name, r, rt.Decl, targetXPathExpr), nil
+}
+
+func (f *csvFormat) FmtErr(format string, args ...interface{}) error {
+	return fmt.Errorf("schema '%s': %s", f.schemaName, fmt.Sprintf(format, args...))
+}

--- a/extensions/omniv21/fileformat/flatfile/csv/format_test.go
+++ b/extensions/omniv21/fileformat/flatfile/csv/format_test.go
@@ -1,0 +1,312 @@
+package csv
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"github.com/jf-tech/go-corelib/jsons"
+	"github.com/jf-tech/go-corelib/strs"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jf-tech/omniparser/errs"
+	"github.com/jf-tech/omniparser/extensions/omniv21/transform"
+	"github.com/jf-tech/omniparser/idr"
+)
+
+func TestValidateSchema(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		format      string
+		fileDecl    string
+		finalOutput *transform.Decl
+		err         string
+	}{
+		{
+			name:        "not supported format",
+			format:      "exe",
+			fileDecl:    "",
+			finalOutput: nil,
+			err:         errs.ErrSchemaNotSupported.Error(),
+		},
+		{
+			name:        "file_declaration JSON schema validation error",
+			format:      fileFormatCSV,
+			fileDecl:    `{}`,
+			finalOutput: nil,
+			err:         `schema 'test' validation failed: (root): file_declaration is required`,
+		},
+		{
+			name:   "group with rows",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [
+							{ "rows": 42, "type": "record_group" }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.records.0.type: file_declaration.records.0.type does not match: \"record\"\nfile_declaration.records.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "group with header",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [
+							{ "header": ".", "type": "record_group" }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.records.0.type: file_declaration.records.0.type does not match: \"record\"\nfile_declaration.records.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "group with columns",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [
+							{ "type": "record_group", "columns": [] }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.records.0.type: file_declaration.records.0.type does not match: \"record\"\nfile_declaration.records.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "both rows and header/footer records",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [
+							{ "rows": 42, "header": "^42$" }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.records.0: Additional property rows is not allowed\nfile_declaration.records.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "multiple target records",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [
+							{ "name": "e1", "is_target": true },
+							{ "name": "e2", "is_target": true }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         `schema 'test': a second record/record_group ('e2') with 'is_target' = true is not allowed`,
+		},
+		{
+			name:   "invalid rows",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [ { "name": "e1", "rows": 0 } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.records.0.rows: Must be greater than or equal to 1\nfile_declaration.records.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "invalid header regex",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [ { "name": "e1", "header": "[" } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': record/record_group 'e1' has an invalid 'header' regexp '[': error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name:   "invalid footer regex",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [ { "name": "e1", "header": ".", "footer": "[" } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': record/record_group 'e1' has an invalid 'footer' regexp '[': error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name:   "invalid type",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [ { "name": "e1", "type": "test" } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test' validation failed:\nfile_declaration.records.0.type: file_declaration.records.0.type does not match: \"record\"\nfile_declaration.records.0: Must validate one and only one schema (oneOf)",
+		},
+		{
+			name:   "min > max",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [ { "name": "e1", "min": 5, "max": 4 } ]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': record/record_group 'e1' has 'min' value 5 > 'max' value 4",
+		},
+		{
+			name:   "invalid line_pattern regexp",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [
+							{
+								"name": "e1",
+								"columns": [{ "name": "c1", "line_pattern": "[" }]
+							}
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         "schema 'test': record 'e1' column 'c1' has an invalid 'line_pattern' regexp '[': error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name:   "FINAL_OUTPUT decl is nil",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : [
+							{ "columns": [{ "name": "c1", "index": 1 }] }
+						]
+					}
+				}`,
+			finalOutput: nil,
+			err:         `schema 'test': 'FINAL_OUTPUT' is missing`,
+		},
+		{
+			name:   "FINAL_OUTPUT xpath is invalid",
+			format: fileFormatCSV,
+			fileDecl: `
+				{
+					"file_declaration": {
+						"delimiter": ",",
+						"records" : []
+					}
+				}`,
+			finalOutput: &transform.Decl{XPath: strs.StrPtr("[")},
+			err:         `schema 'test': 'FINAL_OUTPUT.xpath' (value: '[') is invalid, err: expression must evaluate to a node-set`,
+		},
+		{
+			name:   "success",
+			format: fileFormatCSV,
+			fileDecl: `
+					{
+						"file_declaration": {
+							"delimiter": ",",
+							"records" : [
+								{
+									"name": "e1", "type": "record_group", "min": 1, "max": 1,
+									"child_records": [
+										{ "name": "e2", "max": 5, "columns": [{ "name": "c1", "index": 2 }] },
+										{ "name": "e2", "header": "^ABC$", "columns": [{ "name": "c2", "line_pattern": "^H00" }] }
+									]
+								}
+							]
+						}
+					}`,
+			finalOutput: &transform.Decl{XPath: strs.StrPtr(".[c1 != 'skip']")},
+			err:         "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runtime, err := NewCSVFileFormat("test").
+				ValidateSchema(test.format, []byte(test.fileDecl), test.finalOutput)
+			if test.err != "" {
+				assert.Error(t, err)
+				assert.Equal(t, test.err, err.Error())
+				assert.Nil(t, runtime)
+			} else {
+				assert.NoError(t, err)
+				cupaloy.SnapshotT(t, jsons.BPM(runtime))
+			}
+		})
+	}
+}
+
+func TestCreateFormatReader(t *testing.T) {
+	test := func(finalOutputXPath *string) {
+		format := NewCSVFileFormat("test-schema")
+		runtime, err := format.ValidateSchema(
+			fileFormatCSV,
+			[]byte(`
+				{
+					"file_declaration": {
+						"delimiter": "|",
+						"records" : [
+							{
+								"rows": 2,
+								"columns": [
+									{ "name": "letters", "index": 2, "line_pattern": "^[a-z]" },
+									{ "name": "numerics", "line_pattern": "^[0-9]" }
+								]
+							}
+						]
+					}
+				}`),
+			&transform.Decl{XPath: finalOutputXPath})
+		assert.NoError(t, err)
+		reader, err := format.CreateFormatReader(
+			"test-input",
+			strings.NewReader("abcd|efgh|jklm\n123|456|789\n"),
+			runtime)
+		assert.NoError(t, err)
+		n, err := reader.Read()
+		assert.NoError(t, err)
+		assert.Equal(t, `{"letters":"efgh","numerics":"789"}`, idr.JSONify2(n))
+		reader.Release(n)
+		n, err = reader.Read()
+		assert.Equal(t, io.EOF, err)
+		assert.Nil(t, n)
+	}
+	test(nil)                                // test without FINAL_OUTPUT xpath filtering.
+	test(strs.StrPtr(".[letters != 'xyz']")) // test with FINAL_OUTPUT xpath filtering.
+
+	// test CreateFormatReader called with invalid target xpath.
+	reader, err := NewCSVFileFormat("test-schema").CreateFormatReader(
+		"test-input",
+		strings.NewReader("abcd\n1234\n"),
+		&csvFormatRuntime{XPath: "["})
+	assert.Error(t, err)
+	assert.Equal(t,
+		"schema 'test-schema': xpath '[' on 'FINAL_OUTPUT' is invalid: expression must evaluate to a node-set",
+		err.Error())
+	assert.Nil(t, reader)
+}

--- a/extensions/omniv21/fileformat/flatfile/csv/validate_test.go
+++ b/extensions/omniv21/fileformat/flatfile/csv/validate_test.go
@@ -148,8 +148,10 @@ func TestValidateFileDecl_Success(t *testing.T) {
 	err := (&validateCtx{}).validateFileDecl(fd)
 	assert.NoError(t, err)
 	assert.Equal(t, "A", fd.Records[0].fqdn)
-	assert.True(t, fd.Records[0].matchHeader(&line{raw: "A_BEGIN"}, ","))
-	assert.True(t, fd.Records[0].matchFooter(&line{raw: "A_END"}, ","))
+	assert.True(t,
+		fd.Records[0].matchHeader(&line{recordStart: 0, recordNum: 1}, []string{"A_BEGIN"}, ","))
+	assert.True(t,
+		fd.Records[0].matchFooter(&line{recordStart: 0, recordNum: 1}, []string{"A_END"}, ","))
 	assert.Equal(t, 1, len(fd.Records[0].childRecDecls))
 	assert.Same(t, fd.Records[0].Children[0], fd.Records[0].childRecDecls[0].(*RecordDecl))
 	assert.Equal(t, "A/B", fd.Records[0].Children[0].fqdn)


### PR DESCRIPTION
Because we use `encoding/csv.Reader.ReuseRecord`, each call of `csv.Reader.Read()` return value `[]string` is a cached slice. Given we need to potentially cache multiple lines thus multiple calls to `Read()`, what's in the `linesBuf.record` is always duplicate!!

We could fix this problem trivially by turning `ReuseRecord` off, but that would incur an allocation cost for vast majority of single-line csv operation. That is completely undesired.

So instead, we ourselves cache all the returned strings from (potentially multiple) calls to `csv.Reader.Rdad()` into `reader.records []string` slice, that managing that buffer ourselves, thus practically eliminate the over-allocation problem. Accordingly, in the `reader.linesBuf`, instead of having a `record []string`, we have `recordStart` and `recordNum` to reference into the `reader.records`.