### PR TITLE
allowing for extra properties in edi file declaration

### DIFF
--- a/extensions/omniv21/samples/edi/1_canadapost_edi_214.schema.json
+++ b/extensions/omniv21/samples/edi/1_canadapost_edi_214.schema.json
@@ -12,6 +12,7 @@
                 "child_segments": [
                     {
                         "name": "GS",
+                        "_comment": "functional group",
                         "child_segments": [
                             {
                                 "name": "scanInfo", "type": "segment_group", "min": 0, "max": -1, "is_target": true,
@@ -26,7 +27,7 @@
                                     {
                                         "name": "N4",
                                         "elements": [
-                                            { "name": "cityName", "index": 1 },
+                                            { "name": "cityName", "index": 1, "_comment": "E19" },
                                             { "name": "provinceCode", "index": 2 },
                                             { "name": "postalCode", "index": 3 },
                                             { "name": "countryCode", "index": 4 }

--- a/extensions/omniv21/samples/edi/2_ups_edi_210.schema.json
+++ b/extensions/omniv21/samples/edi/2_ups_edi_210.schema.json
@@ -14,6 +14,7 @@
                 "child_segments": [
                     {
                         "name": "GS",
+                        "_comment": "functional group",
                         "child_segments": [
                             {
                                 "name": "invoiceInfo", "type": "segment_group", "min": 0, "max": -1, "is_target": true,
@@ -74,7 +75,7 @@
                                                 "elements": [
                                                     { "name": "refIdQualifier_N901", "index": 1 },
                                                     { "name": "refId_N902", "index": 2, "default": "" },
-                                                    { "name": "date", "index": 4, "default": "" },
+                                                    { "name": "date", "index": 4, "default": "", "_comment": "YYYYMMDD"},
                                                     { "name": "product_code_C04004", "index": 7, "component_index": 4, "default": "" }
                                                 ]
                                             },

--- a/extensions/omniv21/validation/ediFileDeclaration.go
+++ b/extensions/omniv21/validation/ediFileDeclaration.go
@@ -27,7 +27,7 @@ const (
                 }
             },
             "required": [ "segment_delimiter", "element_delimiter", "segment_declarations" ],
-            "additionalProperties": false
+            "additionalProperties": true
         }
     },
     "required": [ "file_declaration" ],
@@ -52,7 +52,7 @@ const (
                             "default": { "type": "string" }
                         },
                         "required": [ "name", "index" ],
-                        "additionalProperties": false
+                        "additionalProperties": true
                     }
                 },
                 "child_segments": {
@@ -63,7 +63,7 @@ const (
                 }
             },
             "required": [ "name" ],
-            "additionalProperties": false
+            "additionalProperties": true
         }
     }
 }

--- a/extensions/omniv21/validation/ediFileDeclaration.go
+++ b/extensions/omniv21/validation/ediFileDeclaration.go
@@ -27,7 +27,7 @@ const (
                 }
             },
             "required": [ "segment_delimiter", "element_delimiter", "segment_declarations" ],
-            "additionalProperties": true
+            "additionalProperties": false
         }
     },
     "required": [ "file_declaration" ],
@@ -49,10 +49,11 @@ const (
                             "index": { "type": "integer", "minimum": 1 },
                             "component_index": { "type": "integer", "minimum": 1 },
                             "empty_if_missing": { "type": "boolean","$comment": "deprecated, use 'default'" },
-                            "default": { "type": "string" }
+                            "default": { "type": "string" },
+                            "_comment": { "$ref": "#/definitions/value_comment" }
                         },
                         "required": [ "name", "index" ],
-                        "additionalProperties": true
+                        "additionalProperties": false
                     }
                 },
                 "child_segments": {
@@ -60,11 +61,13 @@ const (
                     "items": {
                       "$ref": "#/definitions/segment_declaration_type"
                     }
-                }
+                },
+                "_comment": { "$ref": "#/definitions/value_comment" }
             },
             "required": [ "name" ],
-            "additionalProperties": true
-        }
+            "additionalProperties": false
+        },
+        "value_comment": { "type": "string" }
     }
 }
 `

--- a/extensions/omniv21/validation/ediFileDeclaration.json
+++ b/extensions/omniv21/validation/ediFileDeclaration.json
@@ -20,7 +20,7 @@
                 }
             },
             "required": [ "segment_delimiter", "element_delimiter", "segment_declarations" ],
-            "additionalProperties": true
+            "additionalProperties": false
         }
     },
     "required": [ "file_declaration" ],
@@ -42,10 +42,11 @@
                             "index": { "type": "integer", "minimum": 1 },
                             "component_index": { "type": "integer", "minimum": 1 },
                             "empty_if_missing": { "type": "boolean","$comment": "deprecated, use 'default'" },
-                            "default": { "type": "string" }
+                            "default": { "type": "string" },
+                            "_comment": { "$ref": "#/definitions/value_comment" }
                         },
                         "required": [ "name", "index" ],
-                        "additionalProperties": true
+                        "additionalProperties": false
                     }
                 },
                 "child_segments": {
@@ -53,10 +54,12 @@
                     "items": {
                       "$ref": "#/definitions/segment_declaration_type"
                     }
-                }
+                },
+                "_comment": { "$ref": "#/definitions/value_comment" }
             },
             "required": [ "name" ],
-            "additionalProperties": true
-        }
+            "additionalProperties": false
+        },
+        "value_comment": { "type": "string" }
     }
 }

--- a/extensions/omniv21/validation/ediFileDeclaration.json
+++ b/extensions/omniv21/validation/ediFileDeclaration.json
@@ -20,7 +20,7 @@
                 }
             },
             "required": [ "segment_delimiter", "element_delimiter", "segment_declarations" ],
-            "additionalProperties": false
+            "additionalProperties": true
         }
     },
     "required": [ "file_declaration" ],
@@ -45,7 +45,7 @@
                             "default": { "type": "string" }
                         },
                         "required": [ "name", "index" ],
-                        "additionalProperties": false
+                        "additionalProperties": true
                     }
                 },
                 "child_segments": {
@@ -56,7 +56,7 @@
                 }
             },
             "required": [ "name" ],
-            "additionalProperties": false
+            "additionalProperties": true
         }
     }
 }


### PR DESCRIPTION
EDI can be very obscure. In order to boost readability, we need to allow for extra unused fields like comments so that anyone can come in and read the file declaration.

For example given the following field:
```
{ "name": "N101", "index": 1 }
```
it would be nice to add a comment in order to give more context:
```
{ "name": "N101", "index": 1, "_comment": "name" }
```