### PR TITLE
Multi-lined envelope reading corruption caused by direct reference into bufio.Reader's internal buffer rollover.

### DIFF
--- a/extensions/omniv21/samples/fixedlength2/fixedlength_test.go
+++ b/extensions/omniv21/samples/fixedlength2/fixedlength_test.go
@@ -108,22 +108,22 @@ func Test4_Nested(t *testing.T) {
 	tests[test4_Nested].doTest(t)
 }
 
-// Benchmark1_Single_Row-8      	   25898	     45728 ns/op	   28169 B/op	     647 allocs/op
+// Benchmark1_Single_Row-8      	   25951	     45776 ns/op	   28213 B/op	     645 allocs/op
 func Benchmark1_Single_Row(b *testing.B) {
 	tests[test1_Single_Row].doBenchmark(b)
 }
 
-// Benchmark2_Multi_Rows-8      	   15338	     78273 ns/op	   30179 B/op	     618 allocs/op
+// Benchmark2_Multi_Rows-8      	   18583	     64240 ns/op	   34056 B/op	     636 allocs/op
 func Benchmark2_Multi_Rows(b *testing.B) {
 	tests[test2_Multi_Rows].doBenchmark(b)
 }
 
-// Benchmark3_Header_Footer-8   	    6390	    178301 ns/op	   76571 B/op	    1501 allocs/op
+// Benchmark3_Header_Footer-8   	    7306	    158797 ns/op	   78666 B/op	    1587 allocs/op
 func Benchmark3_Header_Footer(b *testing.B) {
 	tests[test3_Header_Footer].doBenchmark(b)
 }
 
-// Benchmark4_Nested-8          	   10000	    107948 ns/op	   78986 B/op	    1535 allocs/op
+// Benchmark4_Nested-8          	   10000	    107955 ns/op	   80929 B/op	    1515 allocs/op
 func Benchmark4_Nested(b *testing.B) {
 	tests[test4_Nested].doBenchmark(b)
 }


### PR DESCRIPTION
BUG: https://github.com/jf-tech/omniparser/issues/213

If we're dealing with multi-lined envelope (either by rows or by header/footer), readLine() will be called several times, thus whatever ios.ByteReadLine, which uses bufio.Reader underneath, returns in a previous call may be potentially be invalidated due to bufio.Reader's internal buf rollover. If we read the previous line directly, it would cause corruption.

To fix the problem the easiest solution would be simply copying the return []byte from ios.ByteReadLine every single time. But for files with single-line envelope, which are the vast majority cases, this copy becomes unnecessary and burdensome on gc. So the trick is to has a flag on reader.linesBuf's last element to tell if it contains a reference into the bufio.Reader's internal buffer, or it's a copy. Every time before we call bufio.Reader read, we check reader.liensBuf's last element flag, if it is not a copy, then we will turn it into a copy.

This way, we optimize for the vast majority cases without needing allocations, and avoid any potential corruptions in the multi-lined envelope cases.

@paulstadler